### PR TITLE
Picovoice fix for daemon-enable 

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -636,11 +636,12 @@ function setupSystemd() {
 	echo "WantedBy=multi-user.target" >>wire-pod.service
 	cat wire-pod.service
 	echo
-	echo "wire-pod.service created, building chipper..."
 	cd chipper
 	if [[ ${STT_SERVICE} == "leopard" ]]; then
+		echo "wire-pod.service created, building chipper with Picovoice STT service..."
 		/usr/local/go/bin/go build cmd-leopard/main.go
 	else
+		echo "wire-pod.service created, building chipper with Coqui STT service..."
 		export CGO_LDFLAGS="-L$HOME/.coqui/"
 		export CGO_CXXFLAGS="-I$HOME/.coqui/"
 		export LD_LIBRARY_PATH="$HOME/.coqui/:$LD_LIBRARY_PATH"

--- a/setup.sh
+++ b/setup.sh
@@ -633,10 +633,14 @@ function setupSystemd() {
 	echo
 	echo "wire-pod.service created, building chipper..."
 	cd chipper
-	export CGO_LDFLAGS="-L$HOME/.coqui/"
-	export CGO_CXXFLAGS="-I$HOME/.coqui/"
-	export LD_LIBRARY_PATH="$HOME/.coqui/:$LD_LIBRARY_PATH"
-	/usr/local/go/bin/go build cmd/main.go
+	if [[ ${STT_SERVICE} == "leopard" ]]; then
+		/usr/local/go/bin/go build cmd-leopard/main.go
+	else
+		export CGO_LDFLAGS="-L$HOME/.coqui/"
+		export CGO_CXXFLAGS="-I$HOME/.coqui/"
+		export LD_LIBRARY_PATH="$HOME/.coqui/:$LD_LIBRARY_PATH"
+		/usr/local/go/bin/go build cmd/main.go
+	fi
 	mv main chipper
 	echo
 	echo "./chipper/chipper has been built!"

--- a/setup.sh
+++ b/setup.sh
@@ -619,6 +619,11 @@ function setupSystemd() {
 		echo "This cannot be done on macOS."
 		exit 1
 	fi
+	if [[ ! -f ./source.sh ]]; then
+  		echo "You need to make a source.sh file. This can be done with the setup.sh script, option 6."
+  		exit 1
+	fi
+	source source.sh
 	echo "[Unit]" >wire-pod.service
 	echo "Description=Wire Escape Pod (coqui)" >>wire-pod.service
 	echo >>wire-pod.service

--- a/setup.sh
+++ b/setup.sh
@@ -619,11 +619,11 @@ function setupSystemd() {
 		echo "This cannot be done on macOS."
 		exit 1
 	fi
-	if [[ ! -f ./source.sh ]]; then
+	if [[ ! -f ./chipper/source.sh ]]; then
   		echo "You need to make a source.sh file. This can be done with the setup.sh script, option 6."
   		exit 1
 	fi
-	source source.sh
+	source ./chipper/source.sh
 	echo "[Unit]" >wire-pod.service
 	echo "Description=Wire Escape Pod (coqui)" >>wire-pod.service
 	echo >>wire-pod.service


### PR DESCRIPTION
This fixes #10 by checking if Picovoice (leopard) is used in source.sh and then choosing the correct STT service to build.