### PR TITLE
Recover from Leopard panic when command is empty

### DIFF
--- a/chipper/pkg/voice_processors/wirepod-leopard/stthandler.go
+++ b/chipper/pkg/voice_processors/wirepod-leopard/stthandler.go
@@ -104,6 +104,7 @@ func sttHandler(reqThing interface{}, isKnowledgeGraph bool) (transcribedString 
 	var leopardSTT leopard.Leopard
 	botNum = botNum + 1
 	justThisBotNum := botNum
+	
 	if !isKnowledgeGraph {
 		if botNum > picovoiceInstances {
 			fmt.Println("Too many bots are connected, sending error to bot " + strconv.Itoa(justThisBotNum))
@@ -176,6 +177,12 @@ func sttHandler(reqThing interface{}, isKnowledgeGraph bool) (transcribedString 
 		logger(err)
 	}
 	vad.SetMode(3)
+	// sometimes leopard panic!
+	defer func() {
+		if err := recover(); err != nil {
+		    logger(err)
+		}
+	}()
 	for {
 		if isKnowledgeGraph {
 			chunk, chunkErr := req1.Stream.Recv()

--- a/chipper/pkg/voice_processors/wirepod-leopard/stthandler.go
+++ b/chipper/pkg/voice_processors/wirepod-leopard/stthandler.go
@@ -104,7 +104,6 @@ func sttHandler(reqThing interface{}, isKnowledgeGraph bool) (transcribedString 
 	var leopardSTT leopard.Leopard
 	botNum = botNum + 1
 	justThisBotNum := botNum
-	
 	if !isKnowledgeGraph {
 		if botNum > picovoiceInstances {
 			fmt.Println("Too many bots are connected, sending error to bot " + strconv.Itoa(justThisBotNum))


### PR DESCRIPTION
Leopard panics when data is empty.

Behaviour:
Sometimes when no input data is sent in terms of voice, 
Leopard panics at the error rather than returning it as a value. 
i.e "panic: runtime error: invalid memory address or nil pointer dereference"

Full trace:
```
Voice timeout threshold reached.
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x8f2990]

goroutine 98 [running]:
github.com/Picovoice/leopard/binding/go.(*nativeLeopardType).nativeProcess(0x21?, 0x8f7094?, {0xc00033a000, 0xe100, 0xe100})
        /root/go/pkg/mod/github.com/!picovoice/leopard/binding/go@v1.1.1/leopard_native.go:228 +0xf0
github.com/Picovoice/leopard/binding/go.(*Leopard).Process(0x2a11ca0?, {0xc00033a000?, 0xc0015992d8?, 0x1?})
        /root/go/pkg/mod/github.com/!picovoice/leopard/binding/go@v1.1.1/leopard.go:201 +0x48
github.com/digital-dream-labs/chipper/pkg/voice_processors/wirepod-leopard.sttHandler({0x9f7e60?, 0xc00025a4d0?}, 0x0)
        /home/tim/ws/wire-pod/chipper/pkg/voice_processors/wirepod-leopard/stthandler.go:281 +0x1a3b
github.com/digital-dream-labs/chipper/pkg/voice_processors/wirepod-leopard.(*Server).ProcessIntent(0x2a18cc0?, 0xc00025a4d0)
        /home/tim/ws/wire-pod/chipper/pkg/voice_processors/wirepod-leopard/intent.go:11 +0x3c
github.com/digital-dream-labs/chipper/pkg/server.(*Server).StreamingIntent(0xc000145080, {0x2a17f40, 0xc00151c190})
        /home/tim/ws/wire-pod/chipper/pkg/server/intent.go:25 +0x1d2
github.com/digital-dream-labs/api/go/chipperpb._ChipperGrpc_StreamingIntent_Handler({0xa840a0?, 0xc000145080}, {0x2a16d90?, 0xc0001f0680})
        /root/go/pkg/mod/github.com/digital-dream-labs/api@v0.0.0-20210824232136-8cc90c1bb12c/go/chipperpb/chipperpb_grpc.pb.go:242 +0x9f
google.golang.org/grpc.(*Server).processStreamingRPC(0xc0000001e0, {0x2a182b0, 0xc001582820}, 0xc001812120, 0xc000240090, 0x2dad440, 0x0)
        /root/go/pkg/mod/google.golang.org/grpc@v1.48.0/server.go:1558 +0xf46
google.golang.org/grpc.(*Server).handleStream(0xc0000001e0, {0x2a182b0, 0xc001582820}, 0xc001812120, 0x0)
        /root/go/pkg/mod/google.golang.org/grpc@v1.48.0/server.go:1640 +0x9d6
google.golang.org/grpc.(*Server).serveStreams.func1.2()
        /root/go/pkg/mod/google.golang.org/grpc@v1.48.0/server.go:932 +0x98
created by google.golang.org/grpc.(*Server).serveStreams.func1
        /root/go/pkg/mod/google.golang.org/grpc@v1.48.0/server.go:930 +0x28a
exit status 2
```

Step to reproduce:
1. Press Vector's button on the head and say nothing. (occasionally)
Or
2. Say "Hey Vector." with no follow-up statement.


Expectation:
When Leopard is unable to find meaningful data from the sound, it should report "No intent was matched"


Trace after proposed solution:

When pressing top button with no follow-up statement:
```
Bot 1 Language: ENGLISH_US
Stream 1 opened.
Bot 1 Stream Type: Opus
Processing...
Speech completed in 2.80 seconds.
runtime error: invalid memory address or nil pointer dereference
No intent was matched.
Bot 0 Intent Sent: intent_system_noaudio
No Parameters Sent
Bot 0 request served.
```

When no statement after "Hey Vector":
```
Bot 2 Language: ENGLISH_US
Stream 2 opened.
Bot 2 Stream Type: Opus
Processing...
Voice timeout threshold reached.
runtime error: invalid memory address or nil pointer dereference
No intent was matched.
Bot 0 Intent Sent: intent_system_noaudio
No Parameters Sent
Bot 0 request served.
```