### PR TITLE
Check presence of KNOWLEDGE_KEY for Houndify

### DIFF
--- a/chipper/pkg/wirepod/preqs/knowledgegraph.go
+++ b/chipper/pkg/wirepod/preqs/knowledgegraph.go
@@ -106,6 +106,9 @@ func kgHoundifyRequestHandler(req sr.SpeechRequest) (string, error) {
 			}
 			transcribedText, _ = ParseSpokenResponse(serverResponse)
 			logger.Println("Transcribed text: " + transcribedText)
+		} else {
+			transcribedText = "Houndify API Key missing."
+			logger.Println("Houndify API Key missing.")	
 		}
 	} else {
 		transcribedText = "Houndify is not enabled."

--- a/chipper/pkg/wirepod/preqs/knowledgegraph.go
+++ b/chipper/pkg/wirepod/preqs/knowledgegraph.go
@@ -92,7 +92,7 @@ func kgHoundifyRequestHandler(req sr.SpeechRequest) (string, error) {
 	var transcribedText string
 	if HoundEnable {
 		logger.Println("Sending requst to Houndify...")
-		if os.Getenv("HOUNDIFY_CLIENT_KEY") != "" {
+		if os.Getenv("HOUNDIFY_CLIENT_KEY") != "" || os.Getenv("KNOWLEDGE_KEY") != "" {
 			req := houndify.VoiceRequest{
 				AudioStream:       bytes.NewReader(req.MicData),
 				UserID:            req.Device,


### PR DESCRIPTION
When `setup.sh` is executed and a knowledge provider is chosen the ID and Key for that knowledge provider is written into `source.sh` as `KNOWLEDGE_ID` and `KNOWLEDGE_KEY`. While the Houndify client is correctly configured, there's a condition that silently prevents the API call to Houndify. The condition checks to make sure that `HOUNDIFY_CLIENT_KEY` is set/not empty. This is never setup by `setup.sh` and always fails. I presume this might have been added sometime in the past to prevent API calls which would always fail.

This PR adds an additional check for `KNOWLEDGE_KEY` so that these requests don't fail in the presence of a correctly configured client by way of `KNOWLEDGE_ID` and `KNOWLEDGE_KEY`. In addition, it logs the failure if both are empty.
