### PR TITLE
Fix null face name

### DIFF
--- a/chipper/webroot/sdkapp/js/faces.js
+++ b/chipper/webroot/sdkapp/js/faces.js
@@ -27,9 +27,12 @@ function renameFace() {
   oldFaceName = x.value.split(":")[1]
   faceId = x.value.split(":")[0]
   newFaceName = window.prompt('Enter the new name here:');
-  fetch("/api-sdk/rename_face?oldname=" + oldFaceName + "&id=" + faceId + "&newname=" + newFaceName)
-    .then (function(){alert("Success!"); refreshFaceList()})
-}
+if(newFaceName = 'null') {
+    window.alert('Face name cannot be empty')
+} else {
+    fetch("/api-sdk/rename_face?oldname=" + oldFaceName + "&id=" + faceId + "&newname=" + newFaceName)
+      .then (function(){alert("Success!"); refreshFaceList()})
+}}
 
 function deleteFace() {
   var x = document.getElementById("faceList");


### PR DESCRIPTION
This pull request fixes a bug where if the name field is empty when changing a name it will be set to null. This causes the Face list to break and Vector to call that person null. This makes it check it is not null and if it is it will present a message saying the face name field cannot be empty.