### PR TITLE
Dynamic API configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 /chipper/botConfig.json
 /chipper/jdocs/*.json
 /chipper/nvm
+/chipper/apiConfig.json

--- a/GOALS.md
+++ b/GOALS.md
@@ -36,7 +36,12 @@
         -	Streaming is supported by their servers and I would like to implement this
 	    -   This would make requests a lot faster
 
+-   Dynamic config - IN PROGRESS
+    -   Rather than using environment variables for API configs, put the variables into a global, updatable struct. This can be exported to JSON
+    -   Will allow the changing of KG or weather provider without restarting wirepod, or even the voice processor itself
+
 -   Implement wire-pod status page
+    -   Status: logs work
     -   Should include:
         -   Bot serial numbers
         -   Saved bot targets (IP addresses)

--- a/chipper/pkg/initwirepod/startserver.go
+++ b/chipper/pkg/initwirepod/startserver.go
@@ -74,7 +74,6 @@ func StartServer(sttInitFunc func() error, sttHandlerFunc interface{}, voiceProc
 	p, err := wp.New(sttInitFunc, sttHandlerFunc, voiceProcessorName)
 	vars.Init()
 	go wpweb.StartWebServer()
-	wp.InitHoundify()
 	go sdkWeb.BeginServer()
 	if err != nil {
 		logger.Println(err)

--- a/chipper/pkg/logger/logger.go
+++ b/chipper/pkg/logger/logger.go
@@ -24,7 +24,7 @@ func Println(a ...any) {
 	}
 }
 
-func LogMatch(a ...any) {
+func LogUI(a ...any) {
 	LogArray = append(LogArray, time.Now().Format("2006.01.02 15:04:05")+": "+fmt.Sprint(a...)+"\n")
 	if len(LogArray) >= 30 {
 		LogArray = LogArray[1:]

--- a/chipper/pkg/servers/jdocs/server.go
+++ b/chipper/pkg/servers/jdocs/server.go
@@ -83,6 +83,7 @@ func (s *JdocServer) ReadDocs(ctx context.Context, req *jdocspb.ReadDocsReq) (*j
 					break
 				}
 			}
+			logger.LogUI("New bot being associated with wire-pod. ESN: " + esn + ", IP: " + ipAddr)
 			if !matched {
 				if !isAlreadyKnown {
 					logger.Println("Bot was not known to wire-pod, creating token and hash (in ReadDocs)")

--- a/chipper/pkg/vars/config.go
+++ b/chipper/pkg/vars/config.go
@@ -29,6 +29,12 @@ type apiConfig struct {
 	} `json:"knowledge"`
 }
 
+func WriteConfigToDisk() {
+	logger.Println("Configuration changed, writing to disk")
+	writeBytes, _ := json.Marshal(APIConfig)
+	os.WriteFile(ApiConfigPath, writeBytes, 0644)
+}
+
 func CreateConfigFromEnv() {
 	// if no config exists, create it
 	if os.Getenv("WEATHERAPI_ENABLED") == "true" {

--- a/chipper/pkg/vars/config.go
+++ b/chipper/pkg/vars/config.go
@@ -1,0 +1,80 @@
+package vars
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/kercre123/chipper/pkg/logger"
+)
+
+// there should be a way to create a JSON configuration for wire-pod, rather than using env vars
+
+const ApiConfigPath = "./apiConfig.json"
+
+var APIConfig apiConfig
+
+type apiConfig struct {
+	Weather struct {
+		Enable   bool   `json:"enable"`
+		Provider string `json:"provider"`
+		Key      string `json:"key"`
+		Unit     string `json:"unit"`
+	} `json:"weather"`
+	Knowledge struct {
+		Enable      bool   `json:"enable"`
+		Provider    string `json:"provider"`
+		Key         string `json:"key"`
+		ID          string `json:"id"`
+		IntentGraph bool   `json:"intentgraph"`
+	} `json:"knowledge"`
+}
+
+func CreateConfigFromEnv() {
+	// if no config exists, create it
+	if os.Getenv("WEATHERAPI_ENABLED") == "true" {
+		APIConfig.Weather.Enable = true
+		APIConfig.Weather.Provider = os.Getenv("WEATHERAPI_PROVIDER")
+		APIConfig.Weather.Key = os.Getenv("WEATHERAPI_KEY")
+		APIConfig.Weather.Unit = os.Getenv("WEATHERAPI_UNIT")
+	} else {
+		APIConfig.Weather.Enable = false
+	}
+	if os.Getenv("KNOWLEDGE_ENABLED") == "true" {
+		APIConfig.Knowledge.Enable = true
+		APIConfig.Knowledge.Provider = os.Getenv("KNOWLEDGE_PROVIDER")
+		if os.Getenv("KNOWLEDGE_PROVIDER") == "houndify" {
+			APIConfig.Knowledge.ID = os.Getenv("KNOWLEDGE_ID")
+		}
+		APIConfig.Knowledge.Key = os.Getenv("KNOWLEDGE_KEY")
+	} else {
+		APIConfig.Knowledge.Enable = false
+	}
+	writeBytes, _ := json.Marshal(APIConfig)
+	os.WriteFile(ApiConfigPath, writeBytes, 0644)
+}
+
+func ReadConfig() {
+	if _, err := os.Stat(ApiConfigPath); err != nil {
+		CreateConfigFromEnv()
+		logger.Println("API config JSON created")
+	} else {
+		// read config
+		configBytes, err := os.ReadFile(ApiConfigPath)
+		if err != nil {
+			APIConfig.Knowledge.Enable = false
+			APIConfig.Weather.Enable = false
+			logger.Println("Failed to read API config file")
+			logger.Println(err)
+			return
+		}
+		err = json.Unmarshal(configBytes, &APIConfig)
+		if err != nil {
+			APIConfig.Knowledge.Enable = false
+			APIConfig.Weather.Enable = false
+			logger.Println("Failed to unmarshal API config JSON")
+			logger.Println(err)
+			return
+		}
+		logger.Println("API config successfully read")
+	}
+}

--- a/chipper/pkg/vars/vars.go
+++ b/chipper/pkg/vars/vars.go
@@ -84,6 +84,9 @@ func Init() {
 	}
 	logger.Println("SDK info path: " + SDKIniPath)
 
+	// load api config (config.go)
+	ReadConfig()
+
 	// load jdocs. if there are any in the old format, convert
 	jdocsDir, err := os.ReadDir("./jdocs")
 	oldJdocsExisted := false

--- a/chipper/pkg/wirepod/config-ws/webserver.go
+++ b/chipper/pkg/wirepod/config-ws/webserver.go
@@ -1,13 +1,11 @@
 package webserver
 
 import (
-	"bufio"
 	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
-	"os/exec"
 	"strconv"
 	"strings"
 
@@ -146,46 +144,27 @@ func apiHandler(w http.ResponseWriter, r *http.Request) {
 	case r.URL.Path == "/api/set_weather_api":
 		weatherProvider := r.FormValue("provider")
 		weatherAPIKey := r.FormValue("api_key")
-		// Patch source.sh
-		lines, err := readLines("source.sh")
-		if err == nil {
-			var outlines []string
-			for _, line := range lines {
-				if strings.HasPrefix(line, "export WEATHERAPI_ENABLED") {
-					if weatherProvider == "" {
-						line = "export WEATHERAPI_ENABLED=false"
-					} else {
-						line = "export WEATHERAPI_ENABLED=true"
-					}
-				} else if strings.HasPrefix(line, "export WEATHERAPI_PROVIDER") {
-					line = "export WEATHERAPI_PROVIDER=" + weatherProvider
-				} else if strings.HasPrefix(line, "export WEATHERAPI_KEY") {
-					line = "export WEATHERAPI_KEY=" + weatherAPIKey
-				}
-				outlines = append(outlines, line)
-			}
-			writeLines(outlines, "source.sh")
-			fmt.Fprintf(w, "Changes saved. Restart needed.")
+		if weatherProvider == "" {
+			vars.APIConfig.Weather.Enable = false
+		} else {
+			vars.APIConfig.Weather.Enable = true
+			vars.APIConfig.Weather.Key = weatherAPIKey
+			vars.APIConfig.Weather.Provider = weatherProvider
 		}
+		vars.WriteConfigToDisk()
+		fmt.Fprintf(w, "Changes successfully applied.")
 		return
 	case r.URL.Path == "/api/get_weather_api":
-		weatherEnabled := 0
+		weatherEnabled := false
 		weatherProvider := ""
 		weatherAPIKey := ""
-		lines, err := readLines("source.sh")
-		if err == nil {
-			for _, line := range lines {
-				if strings.HasPrefix(line, "export WEATHERAPI_ENABLED=true") {
-					weatherEnabled = 1
-				} else if strings.HasPrefix(line, "export WEATHERAPI_PROVIDER=") {
-					weatherProvider = strings.SplitAfter(line, "export WEATHERAPI_PROVIDER=")[1]
-				} else if strings.HasPrefix(line, "export WEATHERAPI_KEY=") {
-					weatherAPIKey = strings.SplitAfter(line, "export WEATHERAPI_KEY=")[1]
-				}
-			}
+		if vars.APIConfig.Weather.Enable {
+			weatherEnabled = true
+			weatherProvider = vars.APIConfig.Weather.Provider
+			weatherAPIKey = vars.APIConfig.Weather.Key
 		}
 		fmt.Fprintf(w, "{ ")
-		fmt.Fprintf(w, "  \"weatherEnabled\": %d,", weatherEnabled)
+		fmt.Fprintf(w, "  \"weatherEnabled\": %t,", weatherEnabled)
 		fmt.Fprintf(w, "  \"weatherProvider\": \"%s\",", weatherProvider)
 		fmt.Fprintf(w, "  \"weatherApiKey\": \"%s\"", weatherAPIKey)
 		fmt.Fprintf(w, "}")
@@ -195,133 +174,93 @@ func apiHandler(w http.ResponseWriter, r *http.Request) {
 		kgAPIKey := r.FormValue("api_key")
 		// for houndify
 		kgAPIID := r.FormValue("api_id")
-		// Patch source.sh
-		lines, err := readLines("source.sh")
-		var outlines []string
-		if err == nil {
-			for _, line := range lines {
-				if strings.HasPrefix(line, "export KNOWLEDGE_ENABLED") {
-					if kgProvider == "" {
-						line = "export KNOWLEDGE_ENABLED=false"
-					} else {
-						line = "export KNOWLEDGE_ENABLED=true"
-					}
-				} else if strings.HasPrefix(line, "export KNOWLEDGE_PROVIDER") {
-					line = "export KNOWLEDGE_PROVIDER=" + kgProvider
-				} else if strings.HasPrefix(line, "export KNOWLEDGE_KEY") {
-					line = "export KNOWLEDGE_KEY=" + kgAPIKey
-				} else if strings.HasPrefix(line, "export KNOWLEDGE_ID") {
-					line = "export KNOWLEDGE_ID=" + kgAPIID
-				}
-				outlines = append(outlines, line)
-			}
-			writeLines(outlines, "source.sh")
-			fmt.Fprintf(w, "Changes saved. Restart needed.")
+		kgIntent := r.FormValue("intent_graph")
+
+		if kgProvider == "" {
+			vars.APIConfig.Knowledge.Enable = false
+		} else {
+			vars.APIConfig.Knowledge.Enable = true
+			vars.APIConfig.Knowledge.Provider = kgProvider
+			vars.APIConfig.Knowledge.Key = kgAPIKey
+			vars.APIConfig.Knowledge.ID = kgAPIID
 		}
+		if kgProvider == "openai" && kgIntent == "true" {
+			vars.APIConfig.Knowledge.IntentGraph = true
+		}
+		vars.WriteConfigToDisk()
+		fmt.Fprintf(w, "Changes successfully applied.")
 		return
 	case r.URL.Path == "/api/get_kg_api":
-		kgEnabled := 0
+		kgEnabled := false
 		kgProvider := ""
 		kgAPIKey := ""
-		lines, err := readLines("source.sh")
-		if err == nil {
-			for _, line := range lines {
-				if strings.HasPrefix(line, "export KNOWLEDGE_ENABLED=true") {
-					kgEnabled = 1
-				} else if strings.HasPrefix(line, "export KNOWLEDGE_PROVIDER=") {
-					kgProvider = strings.SplitAfter(line, "export KNOWLEDGE_PROVIDER=")[1]
-				} else if strings.HasPrefix(line, "export KNOWLEDGE_KEY=") {
-					kgAPIKey = strings.SplitAfter(line, "export KNOWLEDGE_KEY=")[1]
-				}
-			}
+		kgAPIID := ""
+		kgIntent := false
+		if vars.APIConfig.Knowledge.Enable {
+			kgEnabled = true
+			kgProvider = vars.APIConfig.Knowledge.Provider
+			kgAPIKey = vars.APIConfig.Knowledge.Key
+			kgAPIID = vars.APIConfig.Knowledge.ID
+			kgIntent = vars.APIConfig.Knowledge.IntentGraph
 		}
 		fmt.Fprintf(w, "{ ")
-		fmt.Fprintf(w, "  \"kgEnabled\": %d,", kgEnabled)
+		fmt.Fprintf(w, "  \"kgEnabled\": %t,", kgEnabled)
 		fmt.Fprintf(w, "  \"kgProvider\": \"%s\",", kgProvider)
-		fmt.Fprintf(w, "  \"kgApiKey\": \"%s\"", kgAPIKey)
+		fmt.Fprintf(w, "  \"kgApiKey\": \"%s\",", kgAPIKey)
+		fmt.Fprintf(w, "  \"kgApiID\": \"%s\",", kgAPIID)
+		fmt.Fprintf(w, "  \"kgIntentGraph\": \"%t\"", kgIntent)
 		fmt.Fprintf(w, "}")
 		return
-	case r.URL.Path == "/api/set_stt_info":
-		language := r.FormValue("language")
+	// language should be done at a lower level, as it requires the download of a model
+	// case r.URL.Path == "/api/set_stt_info":
+	// 	language := r.FormValue("language")
 
-		// Patch source.sh
-		lines, err := readLines("source.sh")
-		var outlines []string
-		if err == nil {
-			for _, line := range lines {
-				if strings.HasPrefix(line, "export STT_LANGUAGE") {
-					line = "export STT_LANGUAGE=" + language
-				}
-				outlines = append(outlines, line)
-			}
-			writeLines(outlines, "source.sh")
-			fmt.Fprintf(w, "Changes saved. Restart needed.")
-		}
-		return
-	case r.URL.Path == "/api/get_stt_info":
-		sttLanguage := ""
-		sttProvider := ""
-		lines, err := readLines("source.sh")
-		if err == nil {
-			for _, line := range lines {
-				if strings.HasPrefix(line, "export STT_SERVICE=") {
-					sttProvider = strings.SplitAfter(line, "export STT_SERVICE=")[1]
-				} else if strings.HasPrefix(line, "export STT_LANGUAGE=") {
-					sttLanguage = strings.SplitAfter(line, "export STT_LANGUAGE=")[1]
-				}
-			}
-		}
-		fmt.Fprintf(w, "{ ")
-		fmt.Fprintf(w, "  \"sttProvider\": \"%s\",", sttProvider)
-		fmt.Fprintf(w, "  \"sttLanguage\": \"%s\"", sttLanguage)
-		fmt.Fprintf(w, "}")
-		return
-	case r.URL.Path == "/api/reset":
-		// im not sure if this works... this is only temporary until a way to restart just the voice processor is added
-		cmd := exec.Command("/bin/sh", "-c", "sudo systemctl restart wire-pod")
-		err := cmd.Run()
-		if err != nil {
-			fmt.Fprintf(w, "%s", err.Error())
-			log.Fatal(err)
-		}
-		return
+	// 	// Patch source.sh
+	// 	lines, err := readLines("source.sh")
+	// 	var outlines []string
+	// 	if err == nil {
+	// 		for _, line := range lines {
+	// 			if strings.HasPrefix(line, "export STT_LANGUAGE") {
+	// 				line = "export STT_LANGUAGE=" + language
+	// 			}
+	// 			outlines = append(outlines, line)
+	// 		}
+	// 		writeLines(outlines, "source.sh")
+	// 		fmt.Fprintf(w, "Changes saved. Restart needed.")
+	// 	}
+	// 	return
+	// case r.URL.Path == "/api/get_stt_info":
+	// 	sttLanguage := ""
+	// 	sttProvider := ""
+	// 	lines, err := readLines("source.sh")
+	// 	if err == nil {
+	// 		for _, line := range lines {
+	// 			if strings.HasPrefix(line, "export STT_SERVICE=") {
+	// 				sttProvider = strings.SplitAfter(line, "export STT_SERVICE=")[1]
+	// 			} else if strings.HasPrefix(line, "export STT_LANGUAGE=") {
+	// 				sttLanguage = strings.SplitAfter(line, "export STT_LANGUAGE=")[1]
+	// 			}
+	// 		}
+	// 	}
+	// 	fmt.Fprintf(w, "{ ")
+	// 	fmt.Fprintf(w, "  \"sttProvider\": \"%s\",", sttProvider)
+	// 	fmt.Fprintf(w, "  \"sttLanguage\": \"%s\"", sttLanguage)
+	// 	fmt.Fprintf(w, "}")
+	// 	return
+	// resets not needed anymore!
+	// case r.URL.Path == "/api/reset":
+	// 	// im not sure if this works... this is only temporary until a way to restart just the voice processor is added
+	// 	cmd := exec.Command("/bin/sh", "-c", "sudo systemctl restart wire-pod")
+	// 	err := cmd.Run()
+	// 	if err != nil {
+	// 		fmt.Fprintf(w, "%s", err.Error())
+	// 		log.Fatal(err)
+	// 	}
+	// 	return
 	case r.URL.Path == "/api/get_logs":
 		fmt.Fprintf(w, logger.LogList)
 		return
 	}
-}
-
-// readLines reads a whole file into memory
-// and returns a slice of its lines.
-func readLines(path string) ([]string, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-
-	var lines []string
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		lines = append(lines, scanner.Text())
-	}
-	return lines, scanner.Err()
-}
-
-// writeLines writes the lines to the given file.
-func writeLines(lines []string, path string) error {
-	file, err := os.Create(path)
-	if err != nil {
-		log.Fatal(err)
-		return err
-	}
-	defer file.Close()
-
-	w := bufio.NewWriter(file)
-	for _, line := range lines {
-		fmt.Fprintln(w, line)
-	}
-	return w.Flush()
 }
 
 func StartWebServer() {

--- a/chipper/pkg/wirepod/preqs/intent_graph.go
+++ b/chipper/pkg/wirepod/preqs/intent_graph.go
@@ -46,12 +46,7 @@ func (s *Server) ProcessIntentGraph(req *vtt.IntentGraphRequest) (*vtt.IntentGra
 	if !successMatched {
 		logger.Println("No intent was matched.")
 		if os.Getenv("KNOWLEDGE_INTENT_GRAPH") == "true" && len([]rune(transcribedText)) >= 8 {
-			apiResponse, err := openaiRequest(transcribedText)
-			if err != nil {
-				sr.BotNum = sr.BotNum - 1
-				ttr.IntentPass(req, "intent_system_noaudio", transcribedText, map[string]string{"": ""}, false, speechReq.BotNum)
-				return nil, nil
-			}
+			apiResponse := openaiRequest(transcribedText)
 			sr.BotNum = sr.BotNum - 1
 			response := &pb.IntentGraphResponse{
 				Session:      req.Session,

--- a/chipper/pkg/wirepod/ttr/matchIntentSend.go
+++ b/chipper/pkg/wirepod/ttr/matchIntentSend.go
@@ -21,14 +21,17 @@ type systemIntentResponseStruct struct {
 }
 
 func IntentPass(req interface{}, intentThing string, speechText string, intentParams map[string]string, isParam bool, justThisBotNum int) (interface{}, error) {
+	var esn string
 	var req1 *vtt.IntentRequest
 	var req2 *vtt.IntentGraphRequest
 	var isIntentGraph bool
 	if str, ok := req.(*vtt.IntentRequest); ok {
 		req1 = str
+		esn = req1.Device
 		isIntentGraph = false
 	} else if str, ok := req.(*vtt.IntentGraphRequest); ok {
 		req2 = str
+		esn = req2.Device
 		isIntentGraph = true
 	}
 	var intentResult pb.IntentResult
@@ -44,9 +47,9 @@ func IntentPass(req interface{}, intentThing string, speechText string, intentPa
 			Action:    intentThing,
 		}
 	}
-	logger.LogMatch("Intent matched: " + intentThing + ", transcribed text: '" + speechText + "'")
+	logger.LogUI("Intent matched: " + intentThing + ", transcribed text: '" + speechText + "', device: " + esn)
 	if isParam {
-		logger.LogMatch("Parameters sent: " + fmt.Sprint(intentParams))
+		logger.LogUI("Parameters sent: " + fmt.Sprint(intentParams))
 	}
 	intent := pb.IntentResponse{
 		IsFinal:      true,

--- a/chipper/pkg/wirepod/ttr/weather.go
+++ b/chipper/pkg/wirepod/ttr/weather.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/kercre123/chipper/pkg/logger"
+	"github.com/kercre123/chipper/pkg/vars"
 )
 
 /* TODO:
@@ -149,17 +150,17 @@ func getWeather(location string, botUnits string, hoursFromNow int) (string, str
 	var speakable_location_string string
 	var temperature string
 	var temperature_unit string
-	weatherAPIEnabled := os.Getenv("WEATHERAPI_ENABLED")
-	weatherAPIKey := os.Getenv("WEATHERAPI_KEY")
-	weatherAPIUnit := os.Getenv("WEATHERAPI_UNIT")
-	weatherAPIProvider := os.Getenv("WEATHERAPI_PROVIDER")
-	if weatherAPIEnabled == "true" && weatherAPIKey != "" {
+	weatherAPIEnabled := vars.APIConfig.Weather.Enable
+	weatherAPIKey := vars.APIConfig.Weather.Key
+	weatherAPIUnit := vars.APIConfig.Weather.Unit
+	weatherAPIProvider := vars.APIConfig.Weather.Provider
+	if weatherAPIEnabled && weatherAPIKey != "" {
 		weatherEnabled = true
-		logger.Println("Weather API Enabled")
+		logger.Println("Weather API enabled")
 	} else {
 		weatherEnabled = false
 		logger.Println("Weather API not enabled, using placeholder")
-		if weatherAPIEnabled == "true" && weatherAPIKey == "" {
+		if weatherAPIEnabled && weatherAPIKey == "" {
 			logger.Println("Weather API enabled, but Weather API key not set")
 		}
 	}

--- a/chipper/weather-map.json
+++ b/chipper/weather-map.json
@@ -349,7 +349,7 @@
     },
     {
         "APIValue": "Overcast", 
-        "CladType": "Rain"
+        "CladType": "Cloudy"
     },
     {
         "APIValue": "Partly cloudy", 

--- a/chipper/webroot/index.html
+++ b/chipper/webroot/index.html
@@ -13,7 +13,7 @@
     <hr>
 
     <div class="main-nav-parent">
-      <div class="main-nav-child"><a href="setup.html"><i class="fa-solid fa-gear"></i><br/>Initial Setup</a></div>
+      <div class="main-nav-child"><a href="setup.html"><i class="fa-solid fa-gear"></i><br/>API Setup</a></div>
       <div class="main-nav-child"><a href="/sdkapp"><i class="fa solid fa-toolbox"></i><br/>Configure Bots</a></div>
       <div class="main-nav-child"><a href="#" onclick="showIntents(); return false;"><i class="fa solid fa-microphone-lines"></i><br/>Custom Intents</a></div>
       <div class="main-nav-child"><a href="#" onclick="showLog(); return false;"><i class="fa-solid fa-file-lines"></i><br/>Log</a></div>
@@ -26,7 +26,7 @@
       Add a custom intent
     </h2>
     <div class="content">
-      <p>It is recommended you read <a href="https://github.com/kercre123/wire-pod/blob/main/README.md" target="_blank">README.md</a></p>
+      <p>It is recommended you read <a href="https://github.com/kercre123/wire-pod/wiki/Things-to-Know#web-interface" target="_blank">the wiki</a></p>
       <div id="addIntentStatus"></div>
       <form id="intentAddForm">
         <label for="nameAdd">Custom intent name:</label>

--- a/chipper/webroot/js/customIntents.js
+++ b/chipper/webroot/js/customIntents.js
@@ -368,7 +368,7 @@ function showLog() {
         xhr.onload = function() {
             logDiv.innerHTML = ""
             if (xhr.response == "") {
-                logP.innerHTML = "No logs yet, you must say a command to Vector."
+                logP.innerHTML = "No logs yet, you must say a command to Vector. (this updates automatically)"
             } else {
                 logP.innerHTML = xhr.response
             }
@@ -459,19 +459,41 @@ function updateWeatherAPI() {
 
 function checkKG() {
     if (document.getElementById("kgProvider").value=="") {
-        document.getElementById("kgKey").value = "";
-        document.getElementById("kgKeySpan").style.display = "none";
-    }
-    else {
-        document.getElementById("kgKeySpan").style.display = "block";
+        document.getElementById("houndifyInput").style.display = "none";
+        document.getElementById("openAIInput").style.display = "none";
+    } else if (document.getElementById("kgProvider").value=="houndify") {
+        document.getElementById("openAIInput").style.display = "none";
+        document.getElementById("houndifyInput").style.display = "block";
+    } else if (document.getElementById("kgProvider").value=="openai") {
+        document.getElementById("openAIInput").style.display = "block";
+        document.getElementById("houndifyInput").style.display = "none";
     }
 }
 
 function sendKGAPIKey(element) {
-    var form = document.getElementById("kgAPIAddForm");
-    var provider = document.getElementById("kgProvider").value;
+    var provider = document.getElementById("kgProvider").value
+    var key = ""
+    var id = ""
+    var intentgraph = ""
 
-    var data = "provider=" + provider + "&api_key=" + form.elements["kgKey"].value;
+    if (provider == "openai") {
+        key = document.getElementById("openAIKey").value
+        if (document.getElementById("intentyes").checked == true) {
+            intentgraph = "true"
+        } else {
+            intentgraph = "false"
+        }
+    } else if (provider == "houndify") {
+        key = document.getElementById("houndKey").value
+        id = document.getElementById("houndID").value
+        intentgraph = "false"
+    } else {
+        key = ""
+        id = ""
+        intentgraph = "false"
+    }
+
+    var data = "provider=" + provider + "&api_key=" + key + "&api_id=" + id + "&intent_graph=" + intentgraph
     var result = document.getElementById('addKGProviderAPIStatus');
     const resultP = document.createElement('p');
     resultP.textContent =  "Saving...";
@@ -492,7 +514,17 @@ function updateKGAPI() {
         .then((response) => {
             obj = JSON.parse(response);
             document.getElementById("kgProvider").value = obj.kgProvider;
-            document.getElementById("kgKey").value = obj.kgApiKey;
+            if (obj.kgProvider == "openai") {
+                document.getElementById("openAIKey").value = obj.kgApiKey;
+                if (obj.kgIntentGraph == "true") {
+                    document.getElementById("intentyes").checked = true;
+                } else {
+                    document.getElementById("intentno").checked = true;
+                }
+            } else if (obj.kgProvider == "houndify") {
+                document.getElementById("houndKey").value = obj.kgApiKey;
+                document.getElementById("houndID").value = obj.kgApiID;
+            }
             checkKG();
         })
 }
@@ -514,15 +546,15 @@ function sendSTTLanguage() {
         })
 }
 
-function updateSTTLanguage() {
-    fetch("/api/get_stt_info")
-        .then(response => response.text())
-        .then((response) => {
-            obj = JSON.parse(response);
-            //document.getElementById("sttProvider").value = obj.sttProvider;
-            document.getElementById("sttLanguage").value = obj.sttLanguage;
-        })
-}
+// function updateSTTLanguage() {
+//     fetch("/api/get_stt_info")
+//         .then(response => response.text())
+//         .then((response) => {
+//             obj = JSON.parse(response);
+//             //document.getElementById("sttProvider").value = obj.sttProvider;
+//             document.getElementById("sttLanguage").value = obj.sttLanguage;
+//         })
+// }
 
 function sendRestart() {
     fetch("/api/reset")

--- a/chipper/webroot/setup.html
+++ b/chipper/webroot/setup.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Wire-Pod Initial Setup</title>
+  <title>Wire-Pod API Setup</title>
   <link rel="stylesheet" type="text/css" href="css/style.css">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script src="https://kit.fontawesome.com/8cdc8cbed9.js" crossorigin="anonymous"></script>
@@ -10,14 +10,14 @@
 <body>
   <div id="outer">
     <div id="content" class="">
-    <h1>Wire-Pod Initial Setup</h1>
+    <h1>Wire-Pod API Setup</h1>
     <hr>
     <div class="main-nav-parent">
       <div class="main-nav-child"><a href="index.html"><i class="fa-solid fa-reply"></i><br/>Back</a></div>
       <div class="main-nav-child"><a href="#" onclick="showWeather(); return false;"><i class="fa solid fa-cloud-sun"></i><br/>Weather</a></div>
       <div class="main-nav-child"><a href="#" onclick="showKG(); return false;"><i class="fa solid fa-diagram-project"></i><br/>Knowledge Graph</a></div>
-      <div class="main-nav-child"><a href="#" onclick="showSTT(); return false;"><i class="fa solid fa-language"></i><br/>STT Language</a></div>
-      <div class="main-nav-child"><a href="#" onclick="showRestart(); return false;"><i class="fa solid fa-arrow-rotate-right"></i><br/>Restart Wire-Pod</a></div>
+      <!--<div class="main-nav-child"><a href="#" onclick="showSTT(); return false;"><i class="fa solid fa-language"></i><br/>STT Language</a></div> -->
+      <!--<div class="main-nav-child"><a href="#" onclick="showRestart(); return false;"><i class="fa solid fa-arrow-rotate-right"></i><br/>Restart Wire-Pod</a></div> -->
     </div>
     <hr>
 
@@ -61,9 +61,21 @@
               <option value="openai">OpenAI</option>
               <option value="houndify">Houndify</option>
             </select><br>
-            <span id="kgKeySpan" style="display:none">
-              <label for="kgKey">Knowledge Graph API Key:</label>
-              <input type="text" name="kgKey" id="kgKey"><br>
+            <span id="houndifyInput" style="display:none">
+              <small>To use Houndify, create an account at <a href=https://www.houndify.com/signup>houndify.com</a>, create a free domain, and enter the Client ID and Key here.</small><br>
+              <label for="houndID">Knowledge Graph Client ID:</label>
+              <input type="text" name="houndID" id="houndID"><br>
+              <label for="houndKey">Knowledge Graph Client Key:</label>
+              <input type="text" name="houndKey" id="houndKey"><br>
+            </span>
+            <span id="openAIInput" style="display:none">
+              <label for="openAIKey">Knowledge Graph API Key:</label>
+              <input type="text" name="openAIKey" id="openAIKey"><br>
+              <small>Would you like to enable the intent graph feature? This forwards the request to OpenAI if the regular intent processor didn't understand what you said.</small><br>
+              <label for="intentyes">Yes</label>
+              <input type="radio" id="intentyes" name="intentgselect" value="yes"><br>
+              <label for="intentno">No</label>
+              <input type="radio" id="intentno" name="intentgselect" value="no">
             </span>
           </form>
 	  <div class="center">
@@ -123,6 +135,5 @@
 <script>
     updateWeatherAPI();
     updateKGAPI();
-    updateSTTLanguage();
 </script>
 </html>


### PR DESCRIPTION
- Environment variables exported to a JSON config
- This config gets read at startup and takes importance over env vars
- This config can be updated during runtime and the voice processor will see that, without a restart
- Only for API keys/config, not for ports or language or stt service
- Remove the "Restart wire-pod" as it isnt needed anymore
- Client ID box pops up for Houndify now
- Intent graph selection for OpenAI pops up now