### PR TITLE
Adding CORS headers to the webserver

### DIFF
--- a/chipper/pkg/wirepod/config-ws/webserver.go
+++ b/chipper/pkg/wirepod/config-ws/webserver.go
@@ -15,6 +15,7 @@ import (
 
 func apiHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Headers", "*")
 	switch {
 	default:
 		http.Error(w, "not found", http.StatusNotFound)

--- a/chipper/pkg/wirepod/config-ws/webserver.go
+++ b/chipper/pkg/wirepod/config-ws/webserver.go
@@ -14,6 +14,7 @@ import (
 )
 
 func apiHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
 	switch {
 	default:
 		http.Error(w, "not found", http.StatusNotFound)
@@ -278,7 +279,7 @@ func StartWebServer() {
 	} else {
 		webPort = "8080"
 	}
-	fmt.Printf("Starting webserver at port " + webPort + " (http://localhost:" + webPort + ")\n")
+	fmt.Printf("Starting vectorxws at port " + webPort + " (http://localhost:" + webPort + ")\n")
 	if err := http.ListenAndServe(":"+webPort, nil); err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Add CORS headers to the webserver. At the moment it helps me building my configuration pages. I run a server on port 8070. I need to make requests to wirepod server running on same host, port 8080. Without this change, I can't use Wirepod WS API in my WS.