### PR TITLE
Add dynamic language switching

### DIFF
--- a/chipper/go.mod
+++ b/chipper/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
 	github.com/alphacep/vosk-api v0.3.45 // indirect
 	github.com/bregydoc/gtranslate v0.0.0-20200913051839-1bd07f6c1fc5 // indirect
+	github.com/cryptix/wav v0.0.0-20180415113528-8bdace674401 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/fogleman/gg v1.3.0 // indirect

--- a/chipper/go.sum
+++ b/chipper/go.sum
@@ -104,6 +104,7 @@ github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/cryptix/wav v0.0.0-20180415113528-8bdace674401 h1:rZ+OHHkwlkYALTEd6AYXSL92K/SEc4fkz+TfweIwu6A=
 github.com/cryptix/wav v0.0.0-20180415113528-8bdace674401/go.mod h1:knK8fd+KPlGGqSUWogv1DQzGTwnfUvAi0cIoWyOG7+U=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/chipper/intent-data/de-DE.json
+++ b/chipper/intent-data/de-DE.json
@@ -1,7 +1,7 @@
 [
   {
     "name" : "intent_names_username_extend",
-    "keyphrases": ["Mein Name ist", "Ich bin", "hier ist" "Ich heiße"]
+    "keyphrases": ["Mein Name ist", "Ich bin", "hier ist", "Ich heiße"]
   },
   {
     "name": "intent_weather_extend",
@@ -53,7 +53,7 @@
   },
   {
     "name": "intent_amazon_signin",
-    "Keyphrasen": ["Enter Alexa", "Registriere dich bei Alexa", "Active Alexa", "Schalte Alexa ein", "aktiviere Alexa",]
+    "Keyphrasen": ["Enter Alexa", "Registriere dich bei Alexa", "Active Alexa", "Schalte Alexa ein", "aktiviere Alexa"]
   },
   {
     "name": "intent_amazon_signin",

--- a/chipper/pkg/initwirepod/startserver.go
+++ b/chipper/pkg/initwirepod/startserver.go
@@ -71,9 +71,10 @@ func StartServer(sttInitFunc func() error, sttHandlerFunc interface{}, voiceProc
 	logger.Init()
 
 	// begin wirepod stuff
-	p, err := wp.New(sttInitFunc, sttHandlerFunc, voiceProcessorName)
 	vars.Init()
+	p, err := wp.New(sttInitFunc, sttHandlerFunc, voiceProcessorName)
 	go wpweb.StartWebServer()
+	wpweb.SttInitFunc = sttInitFunc
 	go sdkWeb.BeginServer()
 	if err != nil {
 		logger.Println(err)

--- a/chipper/pkg/vars/config.go
+++ b/chipper/pkg/vars/config.go
@@ -27,6 +27,10 @@ type apiConfig struct {
 		ID          string `json:"id"`
 		IntentGraph bool   `json:"intentgraph"`
 	} `json:"knowledge"`
+	STT struct {
+		Service  string `json:"provider"`
+		Language string `json:"language"`
+	}
 }
 
 func WriteConfigToDisk() {
@@ -59,6 +63,15 @@ func CreateConfigFromEnv() {
 	os.WriteFile(ApiConfigPath, writeBytes, 0644)
 }
 
+func WriteSTT() {
+	// was not part of the original code, so this is its own function
+	// launched if stt not found in config
+	APIConfig.STT.Service = os.Getenv("STT_SERVICE")
+	if os.Getenv("STT_SERVICE") == "vosk" {
+		APIConfig.STT.Language = os.Getenv("STT_LANGUAGE")
+	}
+}
+
 func ReadConfig() {
 	if _, err := os.Stat(ApiConfigPath); err != nil {
 		CreateConfigFromEnv()
@@ -80,6 +93,11 @@ func ReadConfig() {
 			logger.Println("Failed to unmarshal API config JSON")
 			logger.Println(err)
 			return
+		}
+		if APIConfig.STT.Service != os.Getenv("STT_SERVICE") {
+			WriteSTT()
+			writeBytes, _ := json.Marshal(APIConfig)
+			os.WriteFile(ApiConfigPath, writeBytes, 0644)
 		}
 		logger.Println("API config successfully read")
 	}

--- a/chipper/pkg/vars/vars.go
+++ b/chipper/pkg/vars/vars.go
@@ -17,6 +17,7 @@ const (
 	BotConfigsPath    string = "./botConfig.json"
 	BotInfoPath       string = "./jdocs/botSdkInfo.json"
 	PodName           string = "wire-pod"
+	VoskModelPath     string = "../vosk/models/"
 )
 
 // /home/name/.anki_vector/
@@ -25,6 +26,8 @@ var BotJdocs []botjdoc
 var BotInfo RobotInfoStore
 var CustomIntents IntentsStruct
 var CustomIntentsExist bool = false
+var DownloadedVoskModels []string
+var ValidVoskModels []string = []string{"en-US", "it-IT", "es-ES", "fr-FR", "de-DE"}
 
 type RobotInfoStore struct {
 	GlobalGUID string `json:"global_guid"`
@@ -87,6 +90,11 @@ func Init() {
 	// load api config (config.go)
 	ReadConfig()
 
+	// check models folder, add all models to DownloadedVoskModels
+	if APIConfig.STT.Service == "vosk" {
+		GetDownloadedVoskModels()
+	}
+
 	// load jdocs. if there are any in the old format, convert
 	jdocsDir, err := os.ReadDir("./jdocs")
 	oldJdocsExisted := false
@@ -144,6 +152,17 @@ func Init() {
 		}
 	}
 	LoadCustomIntents()
+}
+
+func GetDownloadedVoskModels() {
+	array, err := os.ReadDir("../vosk/models/")
+	if err != nil {
+		logger.Println(err)
+		return
+	}
+	for _, dir := range array {
+		DownloadedVoskModels = append(DownloadedVoskModels, dir.Name())
+	}
 }
 
 func LoadCustomIntents() {

--- a/chipper/pkg/wirepod/config-ws/download.go
+++ b/chipper/pkg/wirepod/config-ws/download.go
@@ -1,0 +1,127 @@
+package webserver
+
+/**
+ * @website http://albulescu.ro
+ * @author Cosmin Albulescu <cosmin@albulescu.ro>
+ */
+// modified from this person's gist ^^^
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"log"
+	"math"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/kercre123/chipper/pkg/logger"
+)
+
+var DownloadStatus string = "not downloading"
+
+func PrintDownloadPercent(done chan int64, path string, total int64) {
+	var stop bool = false
+	for {
+		select {
+		case <-done:
+			stop = true
+		default:
+			file, err := os.Open(path)
+			if err != nil {
+				log.Fatal(err)
+			}
+			fi, err := file.Stat()
+			if err != nil {
+				log.Fatal(err)
+			}
+			size := fi.Size()
+			if size == 0 {
+				size = 1
+			}
+			var percent float64 = float64(size) / float64(total) * 100
+			showPercent := math.Floor(percent)
+			DownloadStatus = "Model download status: " + fmt.Sprint(showPercent) + "%"
+		}
+		if stop {
+			DownloadStatus = "completed"
+			break
+		}
+		time.Sleep(time.Second / 2)
+	}
+}
+
+func DownloadFile(url string, dest string) {
+	if strings.Contains(DownloadStatus, "success") || strings.Contains(DownloadStatus, "error") || strings.Contains(DownloadStatus, "not downloading") {
+		logger.Println("Downloading " + url + " to " + dest)
+		out, _ := os.Create(dest)
+		defer out.Close()
+		headResp, err := http.Head(url)
+		if err != nil {
+			logger.Println(err)
+			DownloadStatus = "error: " + err.Error()
+			return
+		}
+		defer headResp.Body.Close()
+		size, _ := strconv.Atoi(headResp.Header.Get("Content-Length"))
+		done := make(chan int64)
+		go PrintDownloadPercent(done, dest, int64(size))
+		resp, err := http.Get(url)
+		if err != nil {
+			DownloadStatus = "error: " + err.Error()
+			logger.Println(err)
+			return
+		}
+		defer resp.Body.Close()
+		n, _ := io.Copy(out, resp.Body)
+		done <- n
+		DownloadStatus = "Completed download"
+	} else {
+		logger.Println("Not downloading model because download is currently happening")
+	}
+}
+
+func UnzipFile(file, dest string) {
+	zipReader, err := zip.OpenReader(file)
+	if err != nil {
+		DownloadStatus = "error downloading: " + err.Error()
+		logger.Println("error opening zip file: %v", err)
+		return
+	}
+	defer zipReader.Close()
+	DownloadStatus = "Unpacking model..."
+
+	for _, f := range zipReader.File {
+		rc, err := f.Open()
+		if err != nil {
+			DownloadStatus = "error downloading: " + err.Error()
+			logger.Println("error opening zip file: %v", err)
+			return
+		}
+		defer rc.Close()
+
+		path := filepath.Join(dest, f.Name)
+		if f.FileInfo().IsDir() {
+			os.MkdirAll(path, f.Mode())
+		} else {
+			f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
+			if err != nil {
+				DownloadStatus = "error downloading: " + err.Error()
+				logger.Println("Error creating file: %v", err)
+				return
+			}
+			defer f.Close()
+
+			_, err = io.Copy(f, rc)
+			if err != nil {
+				DownloadStatus = "error downloading: " + err.Error()
+				logger.Println("Error writing to file: %v", err)
+				return
+			}
+		}
+	}
+}

--- a/chipper/pkg/wirepod/speechrequest/speechrequest.go
+++ b/chipper/pkg/wirepod/speechrequest/speechrequest.go
@@ -3,7 +3,6 @@ package speechrequest
 import (
 	"encoding/binary"
 	"errors"
-	"os"
 	"strconv"
 
 	pb "github.com/digital-dream-labs/api/go/chipperpb"
@@ -19,7 +18,6 @@ import (
 var BotNum = 0
 
 // need a good place for everywhere to be able to see this without causing import cycle
-var SttLanguage = "en-US"
 
 type SpeechRequest struct {
 	Device         string
@@ -37,13 +35,6 @@ type SpeechRequest struct {
 	IsOpus         bool
 	OpusStream     opus.OggStream
 	BotNum         int
-}
-
-func InitLanguage() {
-	SttLanguage = os.Getenv("STT_LANGUAGE")
-	if len(SttLanguage) == 0 {
-		SttLanguage = "en-US"
-	}
 }
 
 func BytesToSamples(buf []byte) []int16 {

--- a/chipper/pkg/wirepod/stt/vosk/Vosk.go
+++ b/chipper/pkg/wirepod/stt/vosk/Vosk.go
@@ -3,20 +3,25 @@ package wirepod_vosk
 import (
 	"encoding/json"
 	"log"
-	"os"
 	"strconv"
 
 	vosk "github.com/alphacep/vosk-api/go"
 	"github.com/kercre123/chipper/pkg/logger"
+	"github.com/kercre123/chipper/pkg/vars"
 	sr "github.com/kercre123/chipper/pkg/wirepod/speechrequest"
 )
 
 var Name string = "vosk"
 
 var model *vosk.VoskModel
+var modelLoaded bool
 
 func Init() error {
-	sttLanguage := os.Getenv("STT_LANGUAGE")
+	if modelLoaded {
+		logger.Println("A model was already loaded, freeing")
+		model.Free()
+	}
+	sttLanguage := vars.APIConfig.STT.Language
 	if len(sttLanguage) == 0 {
 		sttLanguage = "en-US"
 	}
@@ -28,6 +33,7 @@ func Init() error {
 		return err
 	}
 	model = aModel
+	modelLoaded = true
 	logger.Println("VOSK model opened")
 	return nil
 }

--- a/chipper/pkg/wirepod/ttr/localization.go
+++ b/chipper/pkg/wirepod/ttr/localization.go
@@ -1,8 +1,6 @@
 package wirepod_ttr
 
-import (
-	sr "github.com/kercre123/chipper/pkg/wirepod/speechrequest"
-)
+import "github.com/kercre123/chipper/pkg/vars"
 
 const STR_WEATHER_IN = "str_weather_in"
 const STR_WEATHER_FORECAST = "str_weather_forecast"
@@ -82,13 +80,13 @@ var texts = map[string][]string{
 func getText(key string) string {
 	var data = texts[key]
 	if data != nil {
-		if sr.SttLanguage == "it-IT" {
+		if vars.APIConfig.STT.Language == "it-IT" {
 			return data[1]
-		} else if sr.SttLanguage == "es-ES" {
+		} else if vars.APIConfig.STT.Language == "es-ES" {
 			return data[2]
-		} else if sr.SttLanguage == "fr-FR" {
+		} else if vars.APIConfig.STT.Language == "fr-FR" {
 			return data[3]
-		} else if sr.SttLanguage == "de-DE" {
+		} else if vars.APIConfig.STT.Language == "de-DE" {
 			return data[4]
 		}
 	}

--- a/chipper/pkg/wirepod/ttr/matchIntentSend.go
+++ b/chipper/pkg/wirepod/ttr/matchIntentSend.go
@@ -12,7 +12,6 @@ import (
 	"github.com/kercre123/chipper/pkg/logger"
 	"github.com/kercre123/chipper/pkg/vars"
 	"github.com/kercre123/chipper/pkg/vtt"
-	sr "github.com/kercre123/chipper/pkg/wirepod/speechrequest"
 )
 
 type systemIntentResponseStruct struct {
@@ -120,7 +119,7 @@ func customIntentHandler(req interface{}, voiceText string, intentList []string,
 						} else if arg == "!intentName" {
 							arg = c.Name
 						} else if arg == "!locale" {
-							arg = sr.SttLanguage
+							arg = vars.APIConfig.STT.Language
 						}
 						args = append(args, arg)
 					}

--- a/chipper/webroot/index.html
+++ b/chipper/webroot/index.html
@@ -16,6 +16,7 @@
       <div class="main-nav-child"><a href="setup.html"><i class="fa-solid fa-gear"></i><br/>API Setup</a></div>
       <div class="main-nav-child"><a href="/sdkapp"><i class="fa solid fa-toolbox"></i><br/>Configure Bots</a></div>
       <div class="main-nav-child"><a href="#" onclick="showIntents(); return false;"><i class="fa solid fa-microphone-lines" id="icon-Intents" name="icon"></i><br/>Custom Intents</a></div>
+      <div class="main-nav-child"><a href="#" onclick="showLanguage(); return false;"><i class="fa-solid fa-language" id="icon-Language" name="icon"></i><br/>Set Language</a></div>
       <div class="main-nav-child"><a href="#" onclick="showLog(); return false;"><i class="fa-solid fa-file-lines" id="icon-Logs" name="icon"></i><br/>Log</a></div>
     </div>
     <hr>
@@ -84,6 +85,26 @@
       <textarea id="botTranscriptedTextArea" rows="4" cols="50">
          loading log...
       </textarea>
+      <hr>
+    </div>
+
+    <div id="section-language" style="display: none;">
+      <h2>STT Language</h2>
+      <div class="center" id="languageStatus"></div>
+      <div id="languageSelectionDiv">
+        <div class="center">
+         <select name="languageSelection" id="languageSelection">
+            <option value="en-US">English (US)</option>
+            <option value="it-IT">Italian (IT)</option>
+            <option value="es-ES">Spanish (ES)</option>
+            <option value="fr-FR">French (FR)</option>
+            <option value="de-DE">German (DE)</option>
+          </select>
+          </div>
+          <div class="center">
+          <button onclick="setSTTLanguage()" type="submit">Set Language</button>
+          </div>
+      </div>
       <hr>
     </div>
     


### PR DESCRIPTION
- "Set Langauge" option re-added to main page of web interface
- STT service/language is now part of the API config
- Add CORS headers to config-ws (fforchino contribution)
- If model doesn't exist, it downloads it from vosk github and unzips it to correct directory
- Live progress of download is reported in web interface
- Only works with VOSK. If not vosk, web interface won't let you change the language
- VOSK frees the already-loaded model and loads the new one, without needing a restart of the program
- New intent file also loaded