### PR TITLE
Fix `sayText()`

### DIFF
--- a/chipper/webroot/sdkapp/js/control.js
+++ b/chipper/webroot/sdkapp/js/control.js
@@ -78,8 +78,8 @@ function stopCamStream() {
 }
 
 function sayText() {
-    sayText = document.getElementById("textSay").value
-    sendForm("/api-sdk/say_text?text=" + sayText)
+    sayTextValue = document.getElementById("textSay").value
+    sendForm("/api-sdk/say_text?text=" + sayTextValue)
 }
 
 keysPressed["w"] = false


### PR DESCRIPTION
`sayText` is a variable defined globally which resolves into a function that was overwriting the `sayText` global variable every time it gots executed, which makes the second call to `sayText()` error because `sayText` now is a text

This fixes that by renaming the `sayText` local variable into `sayTextValue`