### PR TITLE
Add support for service recovery on failure

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -487,9 +487,13 @@ function setupSystemd() {
     source ./chipper/source.sh
     echo "[Unit]" >wire-pod.service
     echo "Description=Wire Escape Pod (coqui)" >>wire-pod.service
+    echo "StartLimitIntervalSec=500" >>wire-pod.service
+    echo "StartLimitBurst=5" >>wire-pod.service
     echo >>wire-pod.service
     echo "[Service]" >>wire-pod.service
     echo "Type=simple" >>wire-pod.service
+    echo "Restart=on-failure" >>wire-pod.service
+    echo "RestartSec=5s" >>wire-pod.service
     echo "WorkingDirectory=$(readlink -f ./chipper)" >>wire-pod.service
     echo "ExecStart=$(readlink -f ./chipper/start.sh)" >>wire-pod.service
     echo >>wire-pod.service


### PR DESCRIPTION
If the service exits due to a failure, it will now wait 5 seconds before attempting to restart the service. If it continues to fail, up to 5 times within 8 minutes, the service will exit and not attempt to restart.