### PR TITLE
Added support for naming robot in OpenAI

### DIFF
--- a/chipper/pkg/vars/config.go
+++ b/chipper/pkg/vars/config.go
@@ -27,6 +27,7 @@ type apiConfig struct {
 		Key         string `json:"key"`
 		ID          string `json:"id"`
 		IntentGraph bool   `json:"intentgraph"`
+		RobotName   string `json:"robotName"`
 	} `json:"knowledge"`
 	STT struct {
 		Service  string `json:"provider"`

--- a/chipper/pkg/wirepod/config-ws/webserver.go
+++ b/chipper/pkg/wirepod/config-ws/webserver.go
@@ -192,6 +192,7 @@ func apiHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		if kgProvider == "openai" && kgIntent == "true" {
 			vars.APIConfig.Knowledge.IntentGraph = true
+			vars.APIConfig.Knowledge.RobotName = r.FormValue("robot_name")
 		}
 		vars.WriteConfigToDisk()
 		fmt.Fprintf(w, "Changes successfully applied.")
@@ -202,19 +203,22 @@ func apiHandler(w http.ResponseWriter, r *http.Request) {
 		kgAPIKey := ""
 		kgAPIID := ""
 		kgIntent := false
+		kgRobotName := ""
 		if vars.APIConfig.Knowledge.Enable {
 			kgEnabled = true
 			kgProvider = vars.APIConfig.Knowledge.Provider
 			kgAPIKey = vars.APIConfig.Knowledge.Key
 			kgAPIID = vars.APIConfig.Knowledge.ID
 			kgIntent = vars.APIConfig.Knowledge.IntentGraph
+			kgRobotName = vars.APIConfig.Knowledge.RobotName
 		}
 		fmt.Fprintf(w, "{ ")
 		fmt.Fprintf(w, "  \"kgEnabled\": %t,", kgEnabled)
 		fmt.Fprintf(w, "  \"kgProvider\": \"%s\",", kgProvider)
 		fmt.Fprintf(w, "  \"kgApiKey\": \"%s\",", kgAPIKey)
 		fmt.Fprintf(w, "  \"kgApiID\": \"%s\",", kgAPIID)
-		fmt.Fprintf(w, "  \"kgIntentGraph\": \"%t\"", kgIntent)
+		fmt.Fprintf(w, "  \"kgIntentGraph\": \"%t\",", kgIntent)
+		fmt.Fprintf(w, "  \"kgRobotName\": \"%s\"", kgRobotName)
 		fmt.Fprintf(w, "}")
 		return
 	case r.URL.Path == "/api/set_stt_info":

--- a/chipper/pkg/wirepod/preqs/knowledgegraph.go
+++ b/chipper/pkg/wirepod/preqs/knowledgegraph.go
@@ -70,7 +70,7 @@ func houndifyKG(req sr.SpeechRequest) string {
 }
 
 func openaiRequest(transcribedText string) string {
-	sendString := "You are a helpful robot called the Anki Vector. You will be given a question asked by a user and you must provide the best answer you can. It may not be punctuated or spelled correctly. Keep the answer concise yet informative. Here is the question: " + "\\" + "\"" + transcribedText + "\\" + "\"" + " , Answer: "
+	sendString := "You are a helpful robot called " + vars.APIConfig.Knowledge.RobotName + ". You will be given a question asked by a user and you must provide the best answer you can. It may not be punctuated or spelled correctly. Keep the answer concise yet informative. Here is the question: " + "\\" + "\"" + transcribedText + "\\" + "\"" + " , Answer: "
 	logger.Println("Making request to OpenAI...")
 	url := "https://api.openai.com/v1/completions"
 	formData := `{

--- a/chipper/webroot/initial.html
+++ b/chipper/webroot/initial.html
@@ -99,14 +99,19 @@
               <input type="text" name="houndKey" id="houndKey"><br>
             </span>
             <span id="openAIInput" style="display:none">
-              <small>To use OpenAI, create an account at <a href="https://beta.openai.com/signup">https://beta.openai.com/signup</a>, create an API key, and enter it here.</small>
+              <small>To use OpenAI, create an account at <a href="https://beta.openai.com/signup">https://beta.openai.com/signup</a>, create an API key, and enter it here.</small><br>
               <label for="openAIKey">Knowledge Graph API Key:</label>
               <input type="text" name="openAIKey" id="openAIKey"><br>
               <small>Would you like to enable the intent graph feature? This forwards the request to OpenAI if the regular intent processor didn't understand what you said.</small><br>
               <label for="intentyes">Yes</label>
-              <input type="radio" id="intentyes" name="intentgselect" value="yes"><br>
+              <input type="radio" id="intentyes" name="intentgselect" value="yes" onclick="checkKG()"><br>
               <label for="intentno">No</label>
-              <input type="radio" id="intentno" name="intentgselect" value="no">
+              <input type="radio" id="intentno" name="intentgselect" value="no" onclick="checkKG()">
+              <span id="openAIRobotNameInput" style="display:none">
+                <br>
+                <label for="openAIRobotName">Robot name:</label>
+                <input type="text" name="openAIRobotName" id="openAIRobotName" placeholder="Anki Vector">
+              </span>
             </span>
           </form>
         <div id="addKGProviderAPIStatus"></div>

--- a/chipper/webroot/js/initial.js
+++ b/chipper/webroot/js/initial.js
@@ -91,11 +91,13 @@ function initKGAPIKey() {
     var key = ""
     var id = ""
     var intentgraph = ""
+    var robotName = ""
 
     if (provider == "openai") {
         key = document.getElementById("openAIKey").value
         if (document.getElementById("intentyes").checked == true) {
             intentgraph = "true"
+            robotName = document.getElementById("openAIRobotName").value
         } else {
             intentgraph = "false"
         }
@@ -109,7 +111,7 @@ function initKGAPIKey() {
         intentgraph = "false"
     }
 
-    var data = "provider=" + provider + "&api_key=" + key + "&api_id=" + id + "&intent_graph=" + intentgraph
+    var data = "provider=" + provider + "&api_key=" + key + "&api_id=" + id + "&intent_graph=" + intentgraph + "&robot_name=" + robotName
     fetch("/api/set_kg_api?" + data)
         .then(response => response.text())
         .then((response) => {

--- a/chipper/webroot/js/main.js
+++ b/chipper/webroot/js/main.js
@@ -519,12 +519,20 @@ function checkKG() {
     if (document.getElementById("kgProvider").value=="") {
         document.getElementById("houndifyInput").style.display = "none";
         document.getElementById("openAIInput").style.display = "none";
+        document.getElementById("openAIRobotNameInput").style.display = "none";
     } else if (document.getElementById("kgProvider").value=="houndify") {
+        document.getElementById("openAIRobotNameInput").style.display = "none";  
         document.getElementById("openAIInput").style.display = "none";
         document.getElementById("houndifyInput").style.display = "block";
     } else if (document.getElementById("kgProvider").value=="openai") {
         document.getElementById("openAIInput").style.display = "block";
         document.getElementById("houndifyInput").style.display = "none";
+
+        if (document.getElementById("intentyes").checked == true) {
+            document.getElementById("openAIRobotNameInput").style.display = "block";
+        } else {
+            document.getElementById("openAIRobotNameInput").style.display = "none";
+        }
     }
 }
 
@@ -533,11 +541,13 @@ function sendKGAPIKey() {
     var key = ""
     var id = ""
     var intentgraph = ""
+    var robotName = ""
 
     if (provider == "openai") {
         key = document.getElementById("openAIKey").value
         if (document.getElementById("intentyes").checked == true) {
             intentgraph = "true"
+            robotName = document.getElementById("openAIRobotName").value
         } else {
             intentgraph = "false"
         }
@@ -551,7 +561,7 @@ function sendKGAPIKey() {
         intentgraph = "false"
     }
 
-    var data = "provider=" + provider + "&api_key=" + key + "&api_id=" + id + "&intent_graph=" + intentgraph
+    var data = "provider=" + provider + "&api_key=" + key + "&api_id=" + id + "&intent_graph=" + intentgraph + "&robot_name=" + robotName
     var result = document.getElementById('addKGProviderAPIStatus');
     const resultP = document.createElement('p');
     resultP.textContent =  "Saving...";
@@ -576,6 +586,7 @@ function updateKGAPI() {
                 document.getElementById("openAIKey").value = obj.kgApiKey;
                 if (obj.kgIntentGraph == "true") {
                     document.getElementById("intentyes").checked = true;
+                    document.getElementById("openAIRobotName").value = obj.kgRobotName;
                 } else {
                     document.getElementById("intentno").checked = true;
                 }

--- a/chipper/webroot/setup.html
+++ b/chipper/webroot/setup.html
@@ -73,9 +73,14 @@
               <input type="text" name="openAIKey" id="openAIKey"><br>
               <small>Would you like to enable the intent graph feature? This forwards the request to OpenAI if the regular intent processor didn't understand what you said.</small><br>
               <label for="intentyes">Yes</label>
-              <input type="radio" id="intentyes" name="intentgselect" value="yes"><br>
+              <input type="radio" id="intentyes" name="intentgselect" value="yes" onclick="checkKG()"><br>
               <label for="intentno">No</label>
-              <input type="radio" id="intentno" name="intentgselect" value="no">
+              <input type="radio" id="intentno" name="intentgselect" value="no" onclick="checkKG()">
+              <span id="openAIRobotNameInput" style="display:none">
+                <br>
+                <label for="openAIRobotName">Robot name:</label>
+                <input type="text" name="openAIRobotName" id="openAIRobotName" placeholder="Anki Vector">
+              </span>
             </span>
           </form>
 	  <div class="center">


### PR DESCRIPTION
* Added RobotName to apiConfig
* Modified apiHandler to include RobotName in appropriate get/set endpoints.
* Modified string sent to OpenAI in openaiRequest so that it includes the new RobotName variable. This allows the user to ask what the Robot's name is (once set) and it will respond with that name.
* Added text input field in initial and regular setup HTML pages that will only show when OpenAI is the provider and the Intent Graph is enabled.
* The default name of the robot as sent to OpenAI is what Wire originally set, "Anki Vector".