### PR TITLE
Localization relocation

### DIFF
--- a/chipper/pkg/initwirepod/startserver.go
+++ b/chipper/pkg/initwirepod/startserver.go
@@ -95,9 +95,13 @@ func BeginWirepodSpecific(sttInitFunc func() error, sttHandlerFunc interface{}, 
 func StartFromProgramInit(sttInitFunc func() error, sttHandlerFunc interface{}, voiceProcessorName string) {
 	err := BeginWirepodSpecific(sttInitFunc, sttHandlerFunc, voiceProcessorName)
 	if err != nil {
-		logger.Println("Wire-pod is not setup. Use the webserver at port 8080 to set up wire-pod.")
+		logger.Println("\033[33m\033[1mWire-pod is not setup. Use the webserver at port 8080 to set up wire-pod.\033[0m")
 	} else if !vars.APIConfig.PastInitialSetup {
-		logger.Println("Wire-pod is not setup. Use the webserver at port 8080 to set up wire-pod.")
+		logger.Println("\033[33m\033[1mWire-pod is not setup. Use the webserver at port 8080 to set up wire-pod.\033[0m")
+	} else if vars.APIConfig.STT.Service == "vosk" && vars.APIConfig.STT.Language == "" {
+		logger.Println("\033[33m\033[1mLanguage value is blank, but STT service is Vosk. Reinitiating setup process.\033[0m")
+		logger.Println("\033[33m\033[1mWire-pod is not setup. Use the webserver at port 8080 to set up wire-pod.\033[0m")
+		vars.APIConfig.PastInitialSetup = false
 	} else {
 		go StartChipper()
 	}

--- a/chipper/pkg/vars/vars.go
+++ b/chipper/pkg/vars/vars.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/digital-dream-labs/api/go/jdocspb"
@@ -28,7 +29,11 @@ var BotInfo RobotInfoStore
 var CustomIntents IntentsStruct
 var CustomIntentsExist bool = false
 var DownloadedVoskModels []string
-var ValidVoskModels []string = []string{"en-US", "it-IT", "es-ES", "fr-FR", "de-DE","pt-BR"}
+
+// here to prevent import cycle (localization restructure)
+var SttInitFunc func() error
+var MatchListList [][]string
+var IntentsList = []string{}
 
 type RobotInfoStore struct {
 	GlobalGUID string `json:"global_guid"`
@@ -39,6 +44,11 @@ type RobotInfoStore struct {
 		GUID      string `json:"guid"`
 		Activated bool   `json:"activated"`
 	} `json:"robots"`
+}
+
+type JsonIntent struct {
+	Name       string   `json:"name"`
+	Keyphrases []string `json:"keyphrases"`
 }
 
 type IntentsStruct []struct {
@@ -177,6 +187,29 @@ func LoadCustomIntents() {
 			logger.Println(intent.Name)
 		}
 	}
+}
+
+func LoadIntents() ([][]string, []string, error) {
+	jsonFile, err := os.ReadFile("./intent-data/" + APIConfig.STT.Language + ".json")
+
+	var matches [][]string
+	var intents []string
+
+	if err == nil {
+		var jsonIntents []JsonIntent
+		err = json.Unmarshal(jsonFile, &jsonIntents)
+		if err != nil {
+			logger.Println("Failed to load intents: " + err.Error())
+		}
+
+		for _, element := range jsonIntents {
+			//logger.Println("Loading intent " + strconv.Itoa(index) + " --> " + element.Name + "( " + strconv.Itoa(len(element.Keyphrases)) + " keyphrases )")
+			intents = append(intents, element.Name)
+			matches = append(matches, element.Keyphrases)
+		}
+		logger.Println("Loaded " + strconv.Itoa(len(jsonIntents)) + " intents and " + strconv.Itoa(len(matches)) + " matches (language: " + APIConfig.STT.Language + ")")
+	}
+	return matches, intents, err
 }
 
 func WriteJdocs() {

--- a/chipper/pkg/wirepod/localization/download.go
+++ b/chipper/pkg/wirepod/localization/download.go
@@ -1,4 +1,4 @@
-package webserver
+package localization
 
 /**
  * @website http://albulescu.ro
@@ -20,9 +20,45 @@ import (
 	"time"
 
 	"github.com/kercre123/chipper/pkg/logger"
+	"github.com/kercre123/chipper/pkg/vars"
 )
 
 var DownloadStatus string = "not downloading"
+
+func DownloadVoskModel(language string) {
+	filename := "vosk-model-small-"
+	if language == "en-US" {
+		filename = filename + "en-us-0.15.zip"
+	} else if language == "it-IT" {
+		filename = filename + "it-0.22.zip"
+	} else if language == "es-ES" {
+		filename = filename + "es-0.42.zip"
+	} else if language == "fr-FR" {
+		filename = filename + "fr-0.22.zip"
+	} else if language == "de-DE" {
+		filename = filename + "de-0.15.zip"
+	} else if language == "pt-BR" {
+		filename = filename + "pt-0.3.zip"
+	} else {
+		logger.Println("Language not valid? " + language)
+		return
+	}
+	os.MkdirAll("../vosk", 0755)
+	url := "https://alphacephei.com/vosk/models/" + filename
+	filepath := os.TempDir() + "/" + filename
+	destpath := "../vosk/models/" + language + "/"
+	DownloadFile(url, filepath)
+	UnzipFile(filepath, destpath)
+	os.Rename(destpath+strings.TrimSuffix(filename, ".zip"), destpath+"model")
+	vars.DownloadedVoskModels = append(vars.DownloadedVoskModels, language)
+	DownloadStatus = "Reloading voice processor"
+	vars.APIConfig.STT.Language = language
+	vars.APIConfig.PastInitialSetup = true
+	vars.WriteConfigToDisk()
+	ReloadVosk()
+	logger.Println("Reloaded voice processor successfully")
+	DownloadStatus = "success"
+}
 
 func PrintDownloadPercent(done chan int64, path string, total int64) {
 	var stop bool = false

--- a/chipper/pkg/wirepod/localization/localization.go
+++ b/chipper/pkg/wirepod/localization/localization.go
@@ -1,6 +1,8 @@
-package wirepod_ttr
+package localization
 
 import "github.com/kercre123/chipper/pkg/vars"
+
+var ValidVoskModels []string = []string{"en-US", "it-IT", "es-ES", "fr-FR", "de-DE", "pt-BR"}
 
 const STR_WEATHER_IN = "str_weather_in"
 const STR_WEATHER_FORECAST = "str_weather_forecast"
@@ -77,7 +79,7 @@ var texts = map[string][]string{
 	STR_FOR:                            {" for ", " per ", " para ", " pour ", " für "},
 }
 
-func getText(key string) string {
+func GetText(key string) string {
 	var data = texts[key]
 	if data != nil {
 		if vars.APIConfig.STT.Language == "it-IT" {
@@ -91,4 +93,11 @@ func getText(key string) string {
 		}
 	}
 	return data[0]
+}
+
+func ReloadVosk() {
+	if vars.APIConfig.STT.Service == "vosk" {
+		vars.SttInitFunc()
+		vars.MatchListList, vars.IntentsList, _ = vars.LoadIntents()
+	}
 }

--- a/chipper/pkg/wirepod/preqs/intent.go
+++ b/chipper/pkg/wirepod/preqs/intent.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 
 	"github.com/kercre123/chipper/pkg/logger"
+	"github.com/kercre123/chipper/pkg/vars"
 	"github.com/kercre123/chipper/pkg/vtt"
 	sr "github.com/kercre123/chipper/pkg/wirepod/speechrequest"
 	ttr "github.com/kercre123/chipper/pkg/wirepod/ttr"
@@ -22,7 +23,7 @@ func (s *Server) ProcessIntent(req *vtt.IntentRequest) (*vtt.IntentResponse, err
 			ttr.IntentPass(req, "intent_system_noaudio", "voice processing error", map[string]string{"error": err.Error()}, true, speechReq.BotNum)
 			return nil, nil
 		}
-		successMatched = ttr.ProcessTextAll(req, transcribedText, matchListList, intentsList, speechReq.IsOpus, speechReq.BotNum)
+		successMatched = ttr.ProcessTextAll(req, transcribedText, vars.MatchListList, vars.IntentsList, speechReq.IsOpus, speechReq.BotNum)
 	} else {
 		intent, slots, err := stiHandler(speechReq)
 		if err != nil {

--- a/chipper/pkg/wirepod/preqs/intent_graph.go
+++ b/chipper/pkg/wirepod/preqs/intent_graph.go
@@ -24,7 +24,7 @@ func (s *Server) ProcessIntentGraph(req *vtt.IntentGraphRequest) (*vtt.IntentGra
 			ttr.IntentPass(req, "intent_system_noaudio", "voice processing error", map[string]string{"error": err.Error()}, true, speechReq.BotNum)
 			return nil, nil
 		}
-		successMatched = ttr.ProcessTextAll(req, transcribedText, matchListList, intentsList, speechReq.IsOpus, speechReq.BotNum)
+		successMatched = ttr.ProcessTextAll(req, transcribedText, vars.MatchListList, vars.IntentsList, speechReq.IsOpus, speechReq.BotNum)
 	} else {
 		intent, slots, err := stiHandler(speechReq)
 		if err != nil {

--- a/chipper/pkg/wirepod/preqs/server.go
+++ b/chipper/pkg/wirepod/preqs/server.go
@@ -1,10 +1,7 @@
 package processreqs
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
-	"strconv"
 
 	"github.com/kercre123/chipper/pkg/logger"
 	"github.com/kercre123/chipper/pkg/vars"
@@ -24,8 +21,6 @@ type JsonIntent struct {
 
 var sttLanguage string = "en-US"
 
-var sttInitFunc func() error
-
 // speech-to-text
 var sttHandler func(sr.SpeechRequest) (string, error)
 
@@ -34,38 +29,11 @@ var stiHandler func(sr.SpeechRequest) (string, map[string]string, error)
 
 var isSti bool = false
 
-var matchListList [][]string
-var intentsList = []string{}
-
 func ReloadVosk() {
 	if vars.APIConfig.STT.Service == "vosk" {
-		sttInitFunc()
-		matchListList, intentsList, _ = loadIntents()
+		vars.SttInitFunc()
+		vars.MatchListList, vars.IntentsList, _ = vars.LoadIntents()
 	}
-}
-
-func loadIntents() ([][]string, []string, error) {
-	sttLanguage = vars.APIConfig.STT.Language
-	jsonFile, err := os.ReadFile("./intent-data/" + vars.APIConfig.STT.Language + ".json")
-
-	var matches [][]string
-	var intents []string
-
-	if err == nil {
-		var jsonIntents []JsonIntent
-		err = json.Unmarshal(jsonFile, &jsonIntents)
-		if err != nil {
-			logger.Println("Failed to load intents: " + err.Error())
-		}
-
-		for _, element := range jsonIntents {
-			//logger.Println("Loading intent " + strconv.Itoa(index) + " --> " + element.Name + "( " + strconv.Itoa(len(element.Keyphrases)) + " keyphrases )")
-			intents = append(intents, element.Name)
-			matches = append(matches, element.Keyphrases)
-		}
-		logger.Println("Loaded " + strconv.Itoa(len(jsonIntents)) + " intents and " + strconv.Itoa(len(matches)) + " matches (language: " + vars.APIConfig.STT.Language + ")")
-	}
-	return matches, intents, err
 }
 
 // New returns a new server
@@ -75,13 +43,14 @@ func New(InitFunc func() error, SttHandler interface{}, voiceProcessor string) (
 	if voiceProcessor != "vosk" {
 		vars.APIConfig.STT.Language = "en-US"
 	}
-	matchListList, intentsList, _ = loadIntents()
+	sttLanguage = vars.APIConfig.STT.Language
+	vars.MatchListList, vars.IntentsList, _ = vars.LoadIntents()
 	logger.Println("Initiating " + voiceProcessor + " voice processor with language " + sttLanguage)
 	err := InitFunc()
 	if err != nil {
 		return nil, err
 	}
-	sttInitFunc = InitFunc
+	vars.SttInitFunc = InitFunc
 
 	// SttHandler can either be `func(sr.SpeechRequest) (string, error)` or `func (sr.SpeechRequest) (string, map[string]string, error)`
 	// second one exists to accomodate Rhino

--- a/chipper/pkg/wirepod/sdkapp/server.go
+++ b/chipper/pkg/wirepod/sdkapp/server.go
@@ -498,7 +498,7 @@ func BeginServer() {
 	} else {
 		webPort = "8080"
 	}
-	logger.Println("Configuration page: http://" + ipAddr + ":" + webPort)
+	logger.Println("\033[1;36mConfiguration page: http://" + ipAddr + ":" + webPort + "\033[0m")
 	if err := http.ListenAndServe(":80", nil); err != nil {
 		logger.Println("A process is already using port 80 - connCheck functionality will not work")
 	}

--- a/chipper/pkg/wirepod/ttr/intentparam.go
+++ b/chipper/pkg/wirepod/ttr/intentparam.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/kercre123/chipper/pkg/logger"
 	"github.com/kercre123/chipper/pkg/vars"
+	lcztn "github.com/kercre123/chipper/pkg/wirepod/localization"
 )
 
 // stt
@@ -103,7 +104,7 @@ func ParamChecker(req interface{}, intent string, speechText string, justThisBot
 	if strings.Contains(intent, "intent_photo_take_extend") {
 		isParam = true
 		newIntent = intent
-		if strings.Contains(speechText, getText(STR_ME)) || strings.Contains(speechText, getText(STR_SELF)) {
+		if strings.Contains(speechText, lcztn.GetText(lcztn.STR_ME)) || strings.Contains(speechText, lcztn.GetText(lcztn.STR_SELF)) {
 			intentParam = "entity_photo_selfie"
 			intentParamValue = "photo_selfie"
 		} else {
@@ -115,17 +116,17 @@ func ParamChecker(req interface{}, intent string, speechText string, justThisBot
 		isParam = true
 		newIntent = "intent_imperative_eyecolor_specific_extend"
 		intentParam = "eye_color"
-		if strings.Contains(speechText, getText(STR_EYE_COLOR_PURPLE)) {
+		if strings.Contains(speechText, lcztn.GetText(lcztn.STR_EYE_COLOR_PURPLE)) {
 			intentParamValue = "COLOR_PURPLE"
-		} else if strings.Contains(speechText, getText(STR_EYE_COLOR_BLUE)) || strings.Contains(speechText, getText(STR_EYE_COLOR_SAPPHIRE)) {
+		} else if strings.Contains(speechText, lcztn.GetText(lcztn.STR_EYE_COLOR_BLUE)) || strings.Contains(speechText, lcztn.GetText(lcztn.STR_EYE_COLOR_SAPPHIRE)) {
 			intentParamValue = "COLOR_BLUE"
-		} else if strings.Contains(speechText, getText(STR_EYE_COLOR_YELLOW)) {
+		} else if strings.Contains(speechText, lcztn.GetText(lcztn.STR_EYE_COLOR_YELLOW)) {
 			intentParamValue = "COLOR_YELLOW"
-		} else if strings.Contains(speechText, getText(STR_EYE_COLOR_TEAL)) || strings.Contains(speechText, getText(STR_EYE_COLOR_TEAL2)) {
+		} else if strings.Contains(speechText, lcztn.GetText(lcztn.STR_EYE_COLOR_TEAL)) || strings.Contains(speechText, lcztn.GetText(lcztn.STR_EYE_COLOR_TEAL2)) {
 			intentParamValue = "COLOR_TEAL"
-		} else if strings.Contains(speechText, getText(STR_EYE_COLOR_GREEN)) {
+		} else if strings.Contains(speechText, lcztn.GetText(lcztn.STR_EYE_COLOR_GREEN)) {
 			intentParamValue = "COLOR_GREEN"
-		} else if strings.Contains(speechText, getText(STR_EYE_COLOR_ORANGE)) {
+		} else if strings.Contains(speechText, lcztn.GetText(lcztn.STR_EYE_COLOR_ORANGE)) {
 			intentParamValue = "COLOR_ORANGE"
 		} else {
 			newIntent = intent
@@ -141,22 +142,22 @@ func ParamChecker(req interface{}, intent string, speechText string, justThisBot
 	} else if strings.Contains(intent, "intent_imperative_volumelevel_extend") {
 		isParam = true
 		newIntent = intent
-		if strings.Contains(speechText, getText(STR_VOLUME_MEDIUM_LOW)) {
+		if strings.Contains(speechText, lcztn.GetText(lcztn.STR_VOLUME_MEDIUM_LOW)) {
 			intentParam = "volume_level"
 			intentParamValue = "VOLUME_2"
-		} else if strings.Contains(speechText, getText(STR_VOLUME_LOW)) || strings.Contains(speechText, getText(STR_VOLUME_QUIET)) {
+		} else if strings.Contains(speechText, lcztn.GetText(lcztn.STR_VOLUME_LOW)) || strings.Contains(speechText, lcztn.GetText(lcztn.STR_VOLUME_QUIET)) {
 			intentParam = "volume_level"
 			intentParamValue = "VOLUME_1"
-		} else if strings.Contains(speechText, getText(STR_VOLUME_MEDIUM_HIGH)) {
+		} else if strings.Contains(speechText, lcztn.GetText(lcztn.STR_VOLUME_MEDIUM_HIGH)) {
 			intentParam = "volume_level"
 			intentParamValue = "VOLUME_4"
-		} else if strings.Contains(speechText, getText(STR_VOLUME_MEDIUM)) || strings.Contains(speechText, getText(STR_VOLUME_NORMAL)) || strings.Contains(speechText, getText(STR_VOLUME_REGULAR)) {
+		} else if strings.Contains(speechText, lcztn.GetText(lcztn.STR_VOLUME_MEDIUM)) || strings.Contains(speechText, lcztn.GetText(lcztn.STR_VOLUME_NORMAL)) || strings.Contains(speechText, lcztn.GetText(lcztn.STR_VOLUME_REGULAR)) {
 			intentParam = "volume_level"
 			intentParamValue = "VOLUME_3"
-		} else if strings.Contains(speechText, getText(STR_VOLUME_HIGH)) || strings.Contains(speechText, getText(STR_VOLUME_LOUD)) {
+		} else if strings.Contains(speechText, lcztn.GetText(lcztn.STR_VOLUME_HIGH)) || strings.Contains(speechText, lcztn.GetText(lcztn.STR_VOLUME_LOUD)) {
 			intentParam = "volume_level"
 			intentParamValue = "VOLUME_5"
-		} else if strings.Contains(speechText, getText(STR_VOLUME_MUTE)) || strings.Contains(speechText, getText(STR_VOLUME_NOTHING)) || strings.Contains(speechText, getText(STR_VOLUME_SILENT)) || strings.Contains(speechText, getText(STR_VOLUME_OFF)) || strings.Contains(speechText, getText(STR_VOLUME_ZERO)) {
+		} else if strings.Contains(speechText, lcztn.GetText(lcztn.STR_VOLUME_MUTE)) || strings.Contains(speechText, lcztn.GetText(lcztn.STR_VOLUME_NOTHING)) || strings.Contains(speechText, lcztn.GetText(lcztn.STR_VOLUME_SILENT)) || strings.Contains(speechText, lcztn.GetText(lcztn.STR_VOLUME_OFF)) || strings.Contains(speechText, lcztn.GetText(lcztn.STR_VOLUME_ZERO)) {
 			// there is no VOLUME_0 :(
 			intentParam = "volume_level"
 			intentParamValue = "VOLUME_1"
@@ -170,12 +171,12 @@ func ParamChecker(req interface{}, intent string, speechText string, justThisBot
 		var nameSplitter string = ""
 		isParam = true
 		newIntent = intent
-		if strings.Contains(speechText, getText(STR_NAME_IS)) {
-			nameSplitter = getText(STR_NAME_IS)
-		} else if strings.Contains(speechText, getText(STR_NAME_IS2)) {
-			nameSplitter = getText(STR_NAME_IS2)
-		} else if strings.Contains(speechText, getText(STR_NAME_IS3)) {
-			nameSplitter = getText(STR_NAME_IS3)
+		if strings.Contains(speechText, lcztn.GetText(lcztn.STR_NAME_IS)) {
+			nameSplitter = lcztn.GetText(lcztn.STR_NAME_IS)
+		} else if strings.Contains(speechText, lcztn.GetText(lcztn.STR_NAME_IS2)) {
+			nameSplitter = lcztn.GetText(lcztn.STR_NAME_IS2)
+		} else if strings.Contains(speechText, lcztn.GetText(lcztn.STR_NAME_IS3)) {
+			nameSplitter = lcztn.GetText(lcztn.STR_NAME_IS3)
 		}
 		if nameSplitter != "" {
 			splitPhrase := strings.SplitAfter(speechText, nameSplitter)
@@ -216,8 +217,8 @@ func ParamChecker(req interface{}, intent string, speechText string, justThisBot
 		isParam = true
 		newIntent = intent
 		intentParam = "given_name"
-		if strings.Contains(speechText, getText(STR_FOR)) {
-			splitPhrase := strings.SplitAfter(speechText, getText(STR_FOR))
+		if strings.Contains(speechText, lcztn.GetText(lcztn.STR_FOR)) {
+			splitPhrase := strings.SplitAfter(speechText, lcztn.GetText(lcztn.STR_FOR))
 			given_name = strings.TrimSpace(splitPhrase[1])
 			if len(splitPhrase) == 3 {
 				given_name = given_name + " " + strings.TrimSpace(splitPhrase[2])
@@ -236,8 +237,8 @@ func ParamChecker(req interface{}, intent string, speechText string, justThisBot
 		isParam = true
 		newIntent = intent
 		intentParam = "given_name"
-		if strings.Contains(speechText, getText(STR_FOR)) {
-			splitPhrase := strings.SplitAfter(speechText, getText(STR_FOR))
+		if strings.Contains(speechText, lcztn.GetText(lcztn.STR_FOR)) {
+			splitPhrase := strings.SplitAfter(speechText, lcztn.GetText(lcztn.STR_FOR))
 			given_name = strings.TrimSpace(splitPhrase[1])
 			if len(splitPhrase) == 3 {
 				given_name = given_name + " " + strings.TrimSpace(splitPhrase[2])
@@ -488,7 +489,7 @@ func prehistoricParamChecker(req interface{}, intent string, speechText string, 
 	if strings.Contains(intent, "intent_photo_take_extend") {
 		isParam = true
 		newIntent = intent
-		if strings.Contains(speechText, getText(STR_ME)) || strings.Contains(speechText, getText(STR_SELF)) {
+		if strings.Contains(speechText, lcztn.GetText(lcztn.STR_ME)) || strings.Contains(speechText, lcztn.GetText(lcztn.STR_SELF)) {
 			intentParam = "entity_photo_selfie"
 			intentParamValue = "photo_selfie"
 		} else {
@@ -501,17 +502,17 @@ func prehistoricParamChecker(req interface{}, intent string, speechText string, 
 		isParam = true
 		newIntent = "intent_imperative_eyecolor_specific_extend"
 		intentParam = "eye_color"
-		if strings.Contains(speechText, getText(STR_EYE_COLOR_PURPLE)) {
+		if strings.Contains(speechText, lcztn.GetText(lcztn.STR_EYE_COLOR_PURPLE)) {
 			intentParamValue = "COLOR_PURPLE"
-		} else if strings.Contains(speechText, getText(STR_EYE_COLOR_BLUE)) || strings.Contains(speechText, getText(STR_EYE_COLOR_SAPPHIRE)) {
+		} else if strings.Contains(speechText, lcztn.GetText(lcztn.STR_EYE_COLOR_BLUE)) || strings.Contains(speechText, lcztn.GetText(lcztn.STR_EYE_COLOR_SAPPHIRE)) {
 			intentParamValue = "COLOR_BLUE"
-		} else if strings.Contains(speechText, getText(STR_EYE_COLOR_YELLOW)) {
+		} else if strings.Contains(speechText, lcztn.GetText(lcztn.STR_EYE_COLOR_YELLOW)) {
 			intentParamValue = "COLOR_YELLOW"
-		} else if strings.Contains(speechText, getText(STR_EYE_COLOR_TEAL)) || strings.Contains(speechText, getText(STR_EYE_COLOR_TEAL2)) {
+		} else if strings.Contains(speechText, lcztn.GetText(lcztn.STR_EYE_COLOR_TEAL)) || strings.Contains(speechText, lcztn.GetText(lcztn.STR_EYE_COLOR_TEAL2)) {
 			intentParamValue = "COLOR_TEAL"
-		} else if strings.Contains(speechText, getText(STR_EYE_COLOR_GREEN)) {
+		} else if strings.Contains(speechText, lcztn.GetText(lcztn.STR_EYE_COLOR_GREEN)) {
 			intentParamValue = "COLOR_GREEN"
-		} else if strings.Contains(speechText, getText(STR_EYE_COLOR_ORANGE)) {
+		} else if strings.Contains(speechText, lcztn.GetText(lcztn.STR_EYE_COLOR_ORANGE)) {
 			intentParamValue = "COLOR_ORANGE"
 		} else {
 			newIntent = intent
@@ -527,22 +528,22 @@ func prehistoricParamChecker(req interface{}, intent string, speechText string, 
 	} else if strings.Contains(intent, "intent_imperative_volumelevel_extend") {
 		isParam = true
 		newIntent = intent
-		if strings.Contains(speechText, getText(STR_VOLUME_MEDIUM_LOW)) {
+		if strings.Contains(speechText, lcztn.GetText(lcztn.STR_VOLUME_MEDIUM_LOW)) {
 			intentParam = "volume_level"
 			intentParamValue = "VOLUME_2"
-		} else if strings.Contains(speechText, getText(STR_VOLUME_LOW)) || strings.Contains(speechText, getText(STR_VOLUME_QUIET)) {
+		} else if strings.Contains(speechText, lcztn.GetText(lcztn.STR_VOLUME_LOW)) || strings.Contains(speechText, lcztn.GetText(lcztn.STR_VOLUME_QUIET)) {
 			intentParam = "volume_level"
 			intentParamValue = "VOLUME_1"
-		} else if strings.Contains(speechText, getText(STR_VOLUME_MEDIUM_HIGH)) {
+		} else if strings.Contains(speechText, lcztn.GetText(lcztn.STR_VOLUME_MEDIUM_HIGH)) {
 			intentParam = "volume_level"
 			intentParamValue = "VOLUME_4"
-		} else if strings.Contains(speechText, getText(STR_VOLUME_MEDIUM)) || strings.Contains(speechText, getText(STR_VOLUME_NORMAL)) || strings.Contains(speechText, getText(STR_VOLUME_REGULAR)) {
+		} else if strings.Contains(speechText, lcztn.GetText(lcztn.STR_VOLUME_MEDIUM)) || strings.Contains(speechText, lcztn.GetText(lcztn.STR_VOLUME_NORMAL)) || strings.Contains(speechText, lcztn.GetText(lcztn.STR_VOLUME_REGULAR)) {
 			intentParam = "volume_level"
 			intentParamValue = "VOLUME_3"
-		} else if strings.Contains(speechText, getText(STR_VOLUME_HIGH)) || strings.Contains(speechText, getText(STR_VOLUME_LOUD)) {
+		} else if strings.Contains(speechText, lcztn.GetText(lcztn.STR_VOLUME_HIGH)) || strings.Contains(speechText, lcztn.GetText(lcztn.STR_VOLUME_LOUD)) {
 			intentParam = "volume_level"
 			intentParamValue = "VOLUME_5"
-		} else if strings.Contains(speechText, getText(STR_VOLUME_MUTE)) || strings.Contains(speechText, getText(STR_VOLUME_NOTHING)) || strings.Contains(speechText, getText(STR_VOLUME_SILENT)) || strings.Contains(speechText, getText(STR_VOLUME_OFF)) || strings.Contains(speechText, getText(STR_VOLUME_ZERO)) {
+		} else if strings.Contains(speechText, lcztn.GetText(lcztn.STR_VOLUME_MUTE)) || strings.Contains(speechText, lcztn.GetText(lcztn.STR_VOLUME_NOTHING)) || strings.Contains(speechText, lcztn.GetText(lcztn.STR_VOLUME_SILENT)) || strings.Contains(speechText, lcztn.GetText(lcztn.STR_VOLUME_OFF)) || strings.Contains(speechText, lcztn.GetText(lcztn.STR_VOLUME_ZERO)) {
 			// there is no VOLUME_0 :(
 			intentParam = "volume_level"
 			intentParamValue = "VOLUME_1"
@@ -556,12 +557,12 @@ func prehistoricParamChecker(req interface{}, intent string, speechText string, 
 		var nameSplitter string = ""
 		isParam = true
 		newIntent = "intent_names_username"
-		if strings.Contains(speechText, getText(STR_NAME_IS)) {
-			nameSplitter = getText(STR_NAME_IS)
-		} else if strings.Contains(speechText, getText(STR_NAME_IS2)) {
-			nameSplitter = getText(STR_NAME_IS2)
-		} else if strings.Contains(speechText, getText(STR_NAME_IS3)) {
-			nameSplitter = getText(STR_NAME_IS3)
+		if strings.Contains(speechText, lcztn.GetText(lcztn.STR_NAME_IS)) {
+			nameSplitter = lcztn.GetText(lcztn.STR_NAME_IS)
+		} else if strings.Contains(speechText, lcztn.GetText(lcztn.STR_NAME_IS2)) {
+			nameSplitter = lcztn.GetText(lcztn.STR_NAME_IS2)
+		} else if strings.Contains(speechText, lcztn.GetText(lcztn.STR_NAME_IS3)) {
+			nameSplitter = lcztn.GetText(lcztn.STR_NAME_IS3)
 		}
 		if nameSplitter != "" {
 			splitPhrase := strings.SplitAfter(speechText, nameSplitter)
@@ -602,8 +603,8 @@ func prehistoricParamChecker(req interface{}, intent string, speechText string, 
 		isParam = true
 		newIntent = "intent_message_playmessage"
 		intentParam = "given_name"
-		if strings.Contains(speechText, getText(STR_FOR)) {
-			splitPhrase := strings.SplitAfter(speechText, getText(STR_FOR))
+		if strings.Contains(speechText, lcztn.GetText(lcztn.STR_FOR)) {
+			splitPhrase := strings.SplitAfter(speechText, lcztn.GetText(lcztn.STR_FOR))
 			given_name = strings.TrimSpace(splitPhrase[1])
 			if len(splitPhrase) == 3 {
 				given_name = given_name + " " + strings.TrimSpace(splitPhrase[2])
@@ -622,8 +623,8 @@ func prehistoricParamChecker(req interface{}, intent string, speechText string, 
 		isParam = true
 		newIntent = "intent_message_recordmessage"
 		intentParam = "given_name"
-		if strings.Contains(speechText, getText(STR_FOR)) {
-			splitPhrase := strings.SplitAfter(speechText, getText(STR_FOR))
+		if strings.Contains(speechText, lcztn.GetText(lcztn.STR_FOR)) {
+			splitPhrase := strings.SplitAfter(speechText, lcztn.GetText(lcztn.STR_FOR))
 			given_name = strings.TrimSpace(splitPhrase[1])
 			if len(splitPhrase) == 3 {
 				given_name = given_name + " " + strings.TrimSpace(splitPhrase[2])

--- a/chipper/pkg/wirepod/ttr/weather.go
+++ b/chipper/pkg/wirepod/ttr/weather.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/kercre123/chipper/pkg/logger"
 	"github.com/kercre123/chipper/pkg/vars"
+	lcztn "github.com/kercre123/chipper/pkg/wirepod/localization"
 )
 
 /* TODO:
@@ -353,8 +354,8 @@ func weatherParser(speechText string, botLocation string, botUnits string) (stri
 	var apiLocation string
 	var speechLocation string
 	var hoursFromNow int
-	if strings.Contains(speechText, getText(STR_WEATHER_IN)) {
-		splitPhrase := strings.SplitAfter(speechText, getText(STR_WEATHER_IN))
+	if strings.Contains(speechText, lcztn.GetText(lcztn.STR_WEATHER_IN)) {
+		splitPhrase := strings.SplitAfter(speechText, lcztn.GetText(lcztn.STR_WEATHER_IN))
 		speechLocation = strings.TrimSpace(splitPhrase[1])
 		if len(splitPhrase) == 3 {
 			speechLocation = speechLocation + " " + strings.TrimSpace(splitPhrase[2])
@@ -377,18 +378,18 @@ func weatherParser(speechText string, botLocation string, botUnits string) (stri
 	}
 	hoursFromNow = 0
 	hours, _, _ := time.Now().Clock()
-	if strings.Contains(speechText, getText(STR_WEATHER_THIS_AFTERNOON)) {
+	if strings.Contains(speechText, lcztn.GetText(lcztn.STR_WEATHER_THIS_AFTERNOON)) {
 		if hours < 14 {
 			hoursFromNow = 14 - hours
 		}
-	} else if strings.Contains(speechText, getText(STR_WEATHER_TONIGHT)) {
+	} else if strings.Contains(speechText, lcztn.GetText(lcztn.STR_WEATHER_TONIGHT)) {
 		if hours < 20 {
 			hoursFromNow = 20 - hours
 		}
-	} else if strings.Contains(speechText, getText(STR_WEATHER_THE_DAY_AFTER_TOMORROW)) {
+	} else if strings.Contains(speechText, lcztn.GetText(lcztn.STR_WEATHER_THE_DAY_AFTER_TOMORROW)) {
 		hoursFromNow = 24 - hours + 24 + 9
-	} else if strings.Contains(speechText, getText(STR_WEATHER_FORECAST)) ||
-		strings.Contains(speechText, getText(STR_WEATHER_TOMORROW)) {
+	} else if strings.Contains(speechText, lcztn.GetText(lcztn.STR_WEATHER_FORECAST)) ||
+		strings.Contains(speechText, lcztn.GetText(lcztn.STR_WEATHER_TOMORROW)) {
 		hoursFromNow = 24 - hours + 9
 	}
 	logger.Println("Looking for forecast " + strconv.Itoa(hoursFromNow) + " hours from now...")

--- a/chipper/webroot/js/ble.js
+++ b/chipper/webroot/js/ble.js
@@ -18,19 +18,36 @@ function showBotAuth() {
 }
 
 function checkBLECapability() {
-    fetch("/api-ble/init")
-        .then(response => response.text())
-        .then((response) => {
-            if (response.includes("success")) {
-                BeginBLESetup()
-            } else if (response.includes("error")) {
-                statusP.innerHTML = "Error initializing bluetooth on the device running wire-pod. Use the following site on any machine with Bluetooth for setup:"
-                authEl.innerHTML = ""
-                authEl.appendChild(statusP)
-                authEl.appendChild(document.createElement("br"))
-                authEl.appendChild(externalSetup)
-            }
-        })
+    // fetch("/api-ble/init")
+    //     .then(response => response.text())
+    //     .then((response) => {
+    //         if (response.includes("success")) {
+    //             BeginBLESetup()
+    //         } else if (response.includes("error")) {
+    //             statusP.innerHTML = "Error initializing bluetooth on the device running wire-pod. Use the following site on any machine with Bluetooth for setup:"
+    //             authEl.innerHTML = ""
+    //             authEl.appendChild(statusP)
+    //             authEl.appendChild(document.createElement("br"))
+    //             authEl.appendChild(externalSetup)
+    //         }
+    //     })
+    authEl.innerHTML = ""
+    m1 = document.createElement("p")
+    m2 = document.createElement("a")
+    m3 = document.createElement("small")
+    m1.innerHTML = "Head to the following site on any device with Bluetooth support to set up your Vector."
+    m2.text = "https://keriganc.com/vector-wirepod-setup"
+    m2.href = "https://keriganc.com/vector-wirepod-setup"
+    m2.target = "_blank"
+    m3.innerHTML = "Note: if you have an OSKR/dev-unlocked robot, follow the instructions in the section below this one BEFORE using the web setup."
+    m1.class = "center"
+    m2.class = "center"
+    m3.class = "center"
+    authEl.appendChild(m1)
+    //authEl.appendChild(document.createElement("br"))
+    authEl.appendChild(m2)
+    authEl.appendChild(document.createElement("br"))
+    authEl.appendChild(m3)
 }
 
 function BeginBLESetup() {

--- a/chipper/webroot/js/ssh.js
+++ b/chipper/webroot/js/ssh.js
@@ -46,7 +46,11 @@ function updateSSHSetup() {
           document.getElementById("oskrSetup").style.display = "block"
           clearInterval(interval)
         } else if (response.includes("error")) {
-          updateSSHStatus(response)
+          resp = response
+          if (response.includes("no route to host")) {
+            resp = "Wire-pod was unable to connect to the robot. Make sure the robot is running OSKR/dev software and that it is on the same network as this wire-pod instance. Also double-check the IP."
+          }
+          updateSSHStatus(resp)
             clearInterval(interval)
             document.getElementById("oskrSetup").style.display = "block"
             return


### PR DESCRIPTION
- Move all language and localization code into one folder (wirepod/localization)
- Add some extra formatting and colors in log
- Special case for if STT service is Vosk but language is blank. Setup initiated again if that is the case
- A more user-friendly error in case of SSH setup error

Next up on the docket is a reimplementation of plugins. There are a couple of ways I can go about this.
1. gRPC. This would be the fastest, probably most correct way to do this. Ensures intercompatibility between languages, makes functions easy to implement. However, we have no real reason to use HTTP/2, unless we want to pipe the audio elsewhere. But, if you want to do that, you may as well create your own chipper implementation.
2. A normal REST API. wire-pod could hook into an API, with its endpoint configured in the web interface. It would send over the processed intent, transcribed text, bot serial, bot IP, and bot token (maybe), and the external API could do its SDK magic. It could also return a special intent/intentparams back to wire-pod and have that be given to the bot. This is essentially the same idea as gRPC, but more simple (at least for me).

Go has a plugins system. It is not great. It requires plugins to be built specifically for the Go version of the system, and with the same EXACT package versions. Because of this, the current plugin implementation is off the table. An external program (written in Python or something) could handle dynamic code addition instead. The goal of this is ease-of-use and the ability to be dynamic. Eventually, I want it to be as simple as a store added to the web interface, which the user can choose plugins from, and they would just work without any compilation or restart of the program.