### PR TITLE
General optimizations

### DIFF
--- a/chipper/intent-data/en-US.json
+++ b/chipper/intent-data/en-US.json
@@ -1,43 +1,43 @@
 [
 	{
 		"name" : "intent_names_username_extend", 
-		"keyphrases": ["name is", "native is", "names", "name's" ]
+		"keyphrases": ["name is", "native is", "names", "name's", "my name is" ]
 	},
 	{	
 		"name": "intent_weather_extend", 
-		"keyphrases" : ["weather", "whether", "the other", "the water", "no other", "weather forecast", "weather tomorrow" ]
+		"keyphrases" : ["weather", "whether", "the other", "the water", "no other", "weather forecast", "weather tomorrow", "whats the weather" ]
 	},
 	{	
 		"name": "intent_names_ask", 
-		"keyphrases" : ["my name", "who am"]
+		"keyphrases" : ["my name", "who am", "who am i"]
 	},
 	{	
 		"name": "intent_imperative_eyecolor",
-		"keyphrases" : ["eye color", "colo", "i call her", "i foller", "icolor", "ecce", "erior", "ichor", "agricola", "change", "oracular", "oracle" ]
+		"keyphrases" : ["eye color", "colo", "i call her", "i foller", "icolor", "ecce", "erior", "ichor", "agricola", "change", "oracular", "oracle", "set your eye color to"]
 	},
 	{	
 		"name": "intent_character_age", 
-		"keyphrases" : ["older", "how old", "old are you", "old or yo", "how there you" ]
+		"keyphrases" : ["older", "how old", "old are you", "old or yo", "how there you"]
 	},
 	{	
 		"name": "intent_explore_start", 
-		"keyphrases" : ["start", "plor", "owing", "tailoring", "oding", "oring", "pling" ]
+		"keyphrases" : ["start", "plor", "owing", "tailoring", "oding", "oring", "pling", "start exploring"]
 	},
 	{	
 		"name": "intent_system_charger", 
-		"keyphrases" : ["charge", "home", "go to your", "church", "find your ch" ]
+		"keyphrases" : ["charge", "home", "go to your", "church", "find your ch", "charger" ]
 	},
 		{	
 		"name": "intent_system_sleep",
-		"keyphrases" : ["flee", "sleep", "sheep" ]
+		"keyphrases" : ["flee", "sleep", "sheep", "go to sleep" ]
 	},
 	{	
 		"name": "intent_greeting_goodmorning", 
-		"keyphrases" : ["morning", "mourning", "mooning", "it bore", "afternoon", "after noon", "after whom" ]
+		"keyphrases" : ["morning", "mourning", "mooning", "it bore", "afternoon", "after noon", "after whom", "good morning" ]
 	},
 		{	
 		"name": "intent_greeting_goodnight", 
-		"keyphrases" : ["night", "might" ]
+		"keyphrases" : ["night", "might", "goodnight" ]
 	},
 		{	
 		"name": "intent_greeting_goodbye", 
@@ -53,7 +53,7 @@
 	},
 	{	
 		"name": "intent_amazon_signin", 
-		"keyphrases" : ["in intellect", "fine in electa", "in alex", "ing alex", "in an elect", "to alex", "in angelica", "up alexa" ]
+		"keyphrases" : ["in intellect", "fine in electa", "in alex", "ing alex", "in an elect", "to alex", "in angelica", "up alexa", "sign in to alexa" ]
 	},
 	{	
 		"name": "intent_amazon_signin", 
@@ -61,11 +61,11 @@
 	},
 	{	
 		"name": "intent_imperative_forward",
-		"keyphrases" : ["forward", "for ward", "for word" ]
+		"keyphrases" : ["forward", "for ward", "for word", "move forward", "forwards" ]
 	},
 	{	
 		"name": "intent_imperative_turnaround", 
-		"keyphrases" : ["around", "one eighty", "one ate he" ]
+		"keyphrases" : ["around", "one eighty", "one ate he", "turn around" ]
 	},
 	{	
 		"name": "intent_imperative_turnleft", 
@@ -77,19 +77,19 @@
 	},
 	{	
 		"name": "intent_play_rollcube",
-		"keyphrases" : ["roll cu", "roll your cu", "all your cu", "roll human", "yorke", "old your he" ]
+		"keyphrases" : ["roll cu", "roll your cu", "all your cu", "roll human", "yorke", "old your he", "roll your cube" ]
 	},
 	{	
 		"name": "intent_play_popawheelie", 
-		"keyphrases" : ["pop a w", "polwhele", "olwen", "i wieland", "do a wheel", "doorstone", "thibetan", "powell", "welst", "a wheel", "willie", "a really", "o' billy" ]
+		"keyphrases" : ["pop a w", "polwhele", "olwen", "i wieland", "do a wheel", "doorstone", "thibetan", "powell", "welst", "a wheel", "willie", "a really", "o' billy", "pop a wheelie", "do a wheel stand" ]
 	},
 	{	
 		"name": "intent_play_fistbump", 
-		"keyphrases" : ["this pomp", "this pump", "bump", "fistb", "fistf", "this book", "pisto", "with pomp", "fison", "first", "fifth", "were fifteen", "if bump", "wisdom", "this bu", "fist bomb", "fist ball", "this ball", "system" ]
+		"keyphrases" : ["this pomp", "this pump", "bump", "fistb", "fistf", "this book", "pisto", "with pomp", "fison", "first", "fifth", "were fifteen", "if bump", "wisdom", "this bu", "fist bomb", "fist ball", "this ball", "system", "fistbump" ]
 	},
 		{	
 		"name": "intent_play_blackjack", 
-		"keyphrases" : ["black", "cards", "game" ]
+		"keyphrases" : ["black", "cards", "game", "play blackjack" ]
 	},
 		{	
 		"name": "intent_imperative_affirmative",
@@ -101,27 +101,27 @@
 	},
 	{	
 		"name": "intent_photo_take_extend", 
-		"keyphrases" : ["photo", "foto", "selby", "capture", "picture" ]
+		"keyphrases" : ["photo", "foto", "selby", "capture", "picture", "take a photo of me" ]
 	},
 	{	
 		"name": "intent_imperative_praise", 
-		"keyphrases" : ["good", "awesome", "also", "as some", "of them", "battle", "t rob", "the ro", "amazing", "woodcourt" ]
+		"keyphrases" : ["good", "awesome", "also", "as some", "of them", "battle", "t rob", "the ro", "amazing", "woodcourt", "good robot" ]
 	},
 	{	
 		"name": "intent_imperative_abuse",
-		"keyphrases" : ["bad", "that ro", "ad ro", "a root", "hate", "horrible" ]
+		"keyphrases" : ["bad", "that ro", "ad ro", "a root", "hate", "horrible", "bad robot" ]
 	},
 	{	
 		"name": "intent_imperative_apologize", 
-		"keyphrases" : ["sorry", "apologize", "apologise", "the tory", "nevermind", "never mind" ]
+		"keyphrases" : ["sorry", "apologize", "apologise", "the tory", "nevermind", "never mind", "im sorry" ]
 	},
 	{	
 		"name": "intent_imperative_backup", 
-		"keyphrases" : ["back" ]
+		"keyphrases" : ["back", "back up", "backwards" ]
 	},
 	{	
 		"name": "intent_imperative_volumedown",
-		"keyphrases" : ["all you down", "volume down", "down volume", "down the volume", "quieter", "down to low", "down to medium" ]
+		"keyphrases" : ["all you down", "volume down", "down volume", "down the volume", "quieter", "turn the volume down" ]
 	},
 	{	
 		"name": "intent_imperative_volumeup", 
@@ -141,19 +141,19 @@
 	},
 	{	
 		"name": "intent_greeting_hello", 
-		"keyphrases" : ["hello", "are you", "our you", "high", "below", "little", "follow", "for you", "far you", "how about you" ]
+		"keyphrases" : ["hello", "are you", "our you", "high", "below", "little", "follow", "for you", "far you", "how about you", "how are you" ]
 	},
 	{	
 		"name": "intent_imperative_come", 
-		"keyphrases" : ["come", "to me" ]
+		"keyphrases" : ["come", "to me", "come here" ]
 	},
 	{	
 		"name": "intent_imperative_love",
-		"keyphrases" : ["love", "dove" ]
+		"keyphrases" : ["love", "dove", "i love you" ]
 	},
 	{	
 		"name": "intent_knowledge_promptquestion", 
-		"keyphrases" : ["question", "weston" ]
+		"keyphrases" : ["question", "weston", "i have a question" ]
 	},
 	{	
 		"name": "intent_clock_checktimer", 
@@ -165,35 +165,35 @@
 	},
 	{	
 		"name": "intent_clock_settimer_extend",
-		"keyphrases" : ["timer", "time for", "time of for", "time or", "time of" ]
+		"keyphrases" : ["timer", "time for", "time of for", "time or", "time of", "set a timer for" ]
 	},
 	{	
 		"name": "intent_clock_time", 
-		"keyphrases" : ["time is it", "the time", "what time", "clock" ]
+		"keyphrases" : ["time is it", "the time", "what time", "clock", "what time is it" ]
 	},
 	{	
 		"name": "intent_imperative_quiet", 
-		"keyphrases" : ["quiet", "stop" ]
+		"keyphrases" : ["quiet", "stop", "be quiet" ]
 	},
 	{	
 		"name": "intent_imperative_dance", 
-		"keyphrases" : ["dance", "dancing", "thence" ]
+		"keyphrases" : ["dance", "dancing", "thence", "dance to the beat", "the beat", "boogie" ]
 	},
 	{	
 		"name": "intent_play_pickupcube",
-		"keyphrases" : ["pickup", "pick up", "bring to me", "bring me", "the beat", "boogie" ]
+		"keyphrases" : ["pickup", "pick up" ]
 	},
 	{	
 		"name": "intent_imperative_fetchcube", 
-		"keyphrases" : ["fetch your cu", "fetch cu", "fetch the cu" ]
+		"keyphrases" : ["fetch your cu", "fetch cu", "fetch the cu", "bring to me", "bring me", "bring me your cube" ]
 	},
 	{	
 		"name": "intent_imperative_findcube", 
-		"keyphrases" : ["your cu", "the cu" ]
+		"keyphrases" : ["your cu", "the cu", "find your cube" ]
 	},
 	{	
 		"name": "intent_play_anytrick", 
-		"keyphrases" : ["trick", "something cool", "some thing cool" ]
+		"keyphrases" : ["trick", "something cool", "some thing cool", "do a trick" ]
 	},
 	{	
 		"name": "intent_message_recordmessage_extend",
@@ -213,6 +213,6 @@
 	},
 	{	
 		"name": "intent_play_keepaway",
-		"keyphrases": ["keepaway", "keep away" ]
+		"keyphrases": ["keepaway", "keep away", "play keepaway" ]
 	}
 ]

--- a/chipper/intent-data/en-US.json
+++ b/chipper/intent-data/en-US.json
@@ -121,7 +121,7 @@
 	},
 	{	
 		"name": "intent_imperative_volumedown",
-		"keyphrases" : ["all you down", "volume down", "down volume", "down the volume", "quieter" ]
+		"keyphrases" : ["all you down", "volume down", "down volume", "down the volume", "quieter", "down to low", "down to medium" ]
 	},
 	{	
 		"name": "intent_imperative_volumeup", 

--- a/chipper/intent-data/en-US.json
+++ b/chipper/intent-data/en-US.json
@@ -141,7 +141,7 @@
 	},
 	{	
 		"name": "intent_greeting_hello", 
-		"keyphrases" : ["hello", "are you", "our you", "high", "below", "little", "follow", "for you", "far you", "how about you", "how are you" ]
+		"keyphrases" : ["hello", "are you", "our you", "high", "below", "little", "follow", "for you", "far you", "how about you", "how are you", "the low", "the loo" ]
 	},
 	{	
 		"name": "intent_imperative_come", 

--- a/chipper/pkg/servers/jdocs/botInfoStorer.go
+++ b/chipper/pkg/servers/jdocs/botInfoStorer.go
@@ -94,10 +94,12 @@ func WriteToIniSecondary(esn, guid, ip string) {
 		}
 	}
 	if !certExists {
-		logger.Println("WriteToIniSecondary: getting session cert from Anki server")
+		logger.Println("WriteToIniSecondary: getting session cert from DDL server")
 		resp, err := http.Get("https://session-certs.token.global.anki-services.com/vic/" + esn)
 		if err != nil {
 			logger.Println(err)
+			logger.Println("The DDL servers are down at the moment. The cert will not be gotten. The Python SDK will not be configured.")
+			return
 		}
 		certBytesOrig, _ := io.ReadAll(resp.Body)
 		block, _ := pem.Decode(certBytesOrig)

--- a/chipper/pkg/servers/token/token.go
+++ b/chipper/pkg/servers/token/token.go
@@ -121,7 +121,12 @@ func WriteTokenHash(esn string, tokenHash string) error {
 		logger.Println(err)
 	}
 	jdoc.JsonDoc = string(jdocJsoc)
-	vars.AddJdoc("vic:"+esn, "vic.AppTokens", jdoc)
+	var ajdoc vars.AJdoc
+	ajdoc.ClientMetadata = jdoc.ClientMetadata
+	ajdoc.DocVersion = jdoc.DocVersion
+	ajdoc.FmtVersion = jdoc.FmtVersion
+	ajdoc.JsonDoc = jdoc.JsonDoc
+	vars.AddJdoc("vic:"+esn, "vic.AppTokens", ajdoc)
 	vars.WriteJdocs()
 	return nil
 }

--- a/chipper/pkg/wirepod/config-ws/webserver.go
+++ b/chipper/pkg/wirepod/config-ws/webserver.go
@@ -182,8 +182,8 @@ func apiHandler(w http.ResponseWriter, r *http.Request) {
 		// for houndify
 		kgAPIID := r.FormValue("api_id")
 		kgIntent := r.FormValue("intent_graph")
-        // for Together AI Service
-        kgModel := r.FormValue("model")
+		// for Together AI Service
+		kgModel := r.FormValue("model")
 
 		if kgProvider == "" {
 			vars.APIConfig.Knowledge.Enable = false
@@ -196,7 +196,14 @@ func apiHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		if kgProvider == "openai" && kgIntent == "true" {
 			vars.APIConfig.Knowledge.IntentGraph = true
-			vars.APIConfig.Knowledge.RobotName = r.FormValue("robot_name")
+			if r.FormValue("robot_name") == "" {
+				vars.APIConfig.Knowledge.RobotName = "Vector"
+			} else {
+				vars.APIConfig.Knowledge.RobotName = r.FormValue("robot_name")
+			}
+		} else if kgProvider == "openai" && kgIntent == "false" {
+			vars.APIConfig.Knowledge.IntentGraph = false
+			vars.APIConfig.Knowledge.RobotName = ""
 		}
 		vars.WriteConfigToDisk()
 		fmt.Fprintf(w, "Changes successfully applied.")
@@ -206,7 +213,7 @@ func apiHandler(w http.ResponseWriter, r *http.Request) {
 		kgProvider := ""
 		kgAPIKey := ""
 		kgAPIID := ""
-        kgModel := ""
+		kgModel := ""
 		kgIntent := false
 		kgRobotName := ""
 		if vars.APIConfig.Knowledge.Enable {

--- a/chipper/pkg/wirepod/localization/download.go
+++ b/chipper/pkg/wirepod/localization/download.go
@@ -129,7 +129,7 @@ func UnzipFile(file, dest string) {
 	zipReader, err := zip.OpenReader(file)
 	if err != nil {
 		DownloadStatus = "error downloading: " + err.Error()
-		logger.Println("error opening zip file: %v", err)
+		logger.Println("error opening zip file:", err)
 		return
 	}
 	defer zipReader.Close()
@@ -139,7 +139,7 @@ func UnzipFile(file, dest string) {
 		rc, err := f.Open()
 		if err != nil {
 			DownloadStatus = "error downloading: " + err.Error()
-			logger.Println("error opening zip file: %v", err)
+			logger.Println("error opening zip file:", err)
 			return
 		}
 		defer rc.Close()
@@ -151,7 +151,7 @@ func UnzipFile(file, dest string) {
 			f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
 			if err != nil {
 				DownloadStatus = "error downloading: " + err.Error()
-				logger.Println("Error creating file: %v", err)
+				logger.Println("Error creating file:", err)
 				return
 			}
 			defer f.Close()
@@ -159,7 +159,7 @@ func UnzipFile(file, dest string) {
 			_, err = io.Copy(f, rc)
 			if err != nil {
 				DownloadStatus = "error downloading: " + err.Error()
-				logger.Println("Error writing to file: %v", err)
+				logger.Println("Error writing to file:", err)
 				return
 			}
 		}

--- a/chipper/pkg/wirepod/localization/localization.go
+++ b/chipper/pkg/wirepod/localization/localization.go
@@ -93,7 +93,7 @@ func GetText(key string) string {
 		} else if vars.APIConfig.STT.Language == "pl-PL" {
 			return data[5]
 		} else if vars.APIConfig.STT.Language == "zh-CN" {
-			return data[6]			
+			return data[6]
 		}
 	}
 	return data[0]
@@ -101,7 +101,7 @@ func GetText(key string) string {
 
 func ReloadVosk() {
 	if vars.APIConfig.STT.Service == "vosk" {
-		vars.SttInitFunc()
 		vars.MatchListList, vars.IntentsList, _ = vars.LoadIntents()
+		vars.SttInitFunc()
 	}
 }

--- a/chipper/pkg/wirepod/localization/localization.go
+++ b/chipper/pkg/wirepod/localization/localization.go
@@ -39,6 +39,44 @@ const STR_NAME_IS2 = "str_name_is1"
 const STR_NAME_IS3 = "str_name_is2"
 const STR_FOR = "str_for"
 
+// for grammer
+var ALL_STR []string = []string{
+	"str_weather_in",
+	"str_weather_forecast",
+	"str_weather_tomorrow",
+	"str_weather_the_day_after_tomorrow",
+	"str_weather_tonight",
+	"str_weather_this_afternoon",
+	"str_eye_color_purple",
+	"str_eye_color_blue",
+	"str_eye_color_sapphire",
+	"str_eye_color_yellow",
+	"str_eye_color_teal",
+	"str_eye_color_teal2",
+	"str_eye_color_green",
+	"str_eye_color_orange",
+	"str_me",
+	"str_self",
+	"str_volume_low",
+	"str_volume_quiet",
+	"str_volume_medium_low",
+	"str_volume_medium",
+	"str_volume_normal",
+	"str_volume_regular",
+	"str_volume_medium_high",
+	"str_volume_high",
+	"str_volume_loud",
+	"str_volume_mute",
+	"str_volume_nothing",
+	"str_volume_silent",
+	"str_volume_off",
+	"str_volume_zero",
+	"str_name_is",
+	"str_name_is1",
+	"str_name_is2",
+	"str_for",
+}
+
 // All text must be lowercase!
 
 var texts = map[string][]string{

--- a/chipper/pkg/wirepod/preqs/intent.go
+++ b/chipper/pkg/wirepod/preqs/intent.go
@@ -15,9 +15,10 @@ func (s *Server) ProcessIntent(req *vtt.IntentRequest) (*vtt.IntentResponse, err
 	sr.BotNum = sr.BotNum + 1
 	var successMatched bool
 	speechReq := sr.ReqToSpeechRequest(req)
-	var transcribedText = ""
+	var transcribedText string
 	if !isSti {
-		transcribedText, err := sttHandler(speechReq)
+		var err error
+		transcribedText, err = sttHandler(speechReq)
 		if err != nil {
 			sr.BotNum = sr.BotNum - 1
 			ttr.IntentPass(req, "intent_system_noaudio", "voice processing error", map[string]string{"error": err.Error()}, true, speechReq.BotNum)
@@ -43,11 +44,10 @@ func (s *Server) ProcessIntent(req *vtt.IntentRequest) (*vtt.IntentResponse, err
 		return nil, nil
 	}
 	if !successMatched {
-		// if vars.APIConfig.Knowledge.IntentGraph {
-		// 	logger.Println("Making request to OpenAI...")
-		// 	resp := openaiRequest(transcribedText)
-		// 	KGSim(req.Device, resp)
-		// }
+		if vars.APIConfig.Knowledge.IntentGraph {
+			resp := openaiRequest(transcribedText)
+			KGSim(req.Device, resp)
+		}
 		logger.Println("No intent was matched.")
 		sr.BotNum = sr.BotNum - 1
 		ttr.IntentPass(req, "intent_system_noaudio", transcribedText, map[string]string{"": ""}, false, speechReq.BotNum)

--- a/chipper/pkg/wirepod/preqs/intent.go
+++ b/chipper/pkg/wirepod/preqs/intent.go
@@ -43,6 +43,11 @@ func (s *Server) ProcessIntent(req *vtt.IntentRequest) (*vtt.IntentResponse, err
 		return nil, nil
 	}
 	if !successMatched {
+		// if vars.APIConfig.Knowledge.IntentGraph {
+		// 	logger.Println("Making request to OpenAI...")
+		// 	resp := openaiRequest(transcribedText)
+		// 	KGSim(req.Device, resp)
+		// }
 		logger.Println("No intent was matched.")
 		sr.BotNum = sr.BotNum - 1
 		ttr.IntentPass(req, "intent_system_noaudio", transcribedText, map[string]string{"": ""}, false, speechReq.BotNum)

--- a/chipper/pkg/wirepod/preqs/kgsim.go
+++ b/chipper/pkg/wirepod/preqs/kgsim.go
@@ -1,0 +1,102 @@
+package processreqs
+
+import (
+	"context"
+	"log"
+
+	"github.com/fforchino/vector-go-sdk/pkg/vector"
+	"github.com/fforchino/vector-go-sdk/pkg/vectorpb"
+	"github.com/kercre123/chipper/pkg/vars"
+)
+
+func KGSim(esn string, textToSay string) error {
+	matched := false
+	var robot *vector.Vector
+	var guid string
+	var target string
+	for _, bot := range vars.BotInfo.Robots {
+		if esn == bot.Esn {
+			guid = bot.GUID
+			target = bot.IPAddress + ":443"
+			matched = true
+			break
+		}
+	}
+	if matched {
+		var err error
+		robot, err = vector.New(vector.WithSerialNo(esn), vector.WithToken(guid), vector.WithTarget(target))
+		if err != nil {
+			return err
+		}
+	}
+	controlRequest := &vectorpb.BehaviorControlRequest{
+		RequestType: &vectorpb.BehaviorControlRequest_ControlRequest{
+			ControlRequest: &vectorpb.ControlRequest{
+				Priority: vectorpb.ControlRequest_OVERRIDE_BEHAVIORS,
+			},
+		},
+	}
+	go func() {
+		start := make(chan bool)
+		stop := make(chan bool)
+		go func() {
+			// * begin - modified from official vector-go-sdk
+			r, err := robot.Conn.BehaviorControl(
+				context.Background(),
+			)
+			if err != nil {
+				log.Println(err)
+				return
+			}
+
+			if err := r.Send(controlRequest); err != nil {
+				log.Println(err)
+				return
+			}
+
+			for {
+				ctrlresp, err := r.Recv()
+				if err != nil {
+					log.Println(err)
+					return
+				}
+				if ctrlresp.GetControlGrantedResponse() != nil {
+					start <- true
+					break
+				}
+			}
+
+			for {
+				select {
+				case <-stop:
+					if err := r.Send(
+						&vectorpb.BehaviorControlRequest{
+							RequestType: &vectorpb.BehaviorControlRequest_ControlRelease{
+								ControlRelease: &vectorpb.ControlRelease{},
+							},
+						},
+					); err != nil {
+						log.Println(err)
+						return
+					}
+					return
+				default:
+					continue
+				}
+			}
+			// * end - modified from official vector-go-sdk
+		}()
+		for range start {
+			robot.Conn.SayText(
+				context.Background(),
+				&vectorpb.SayTextRequest{
+					Text:           textToSay,
+					UseVectorVoice: true,
+					DurationScalar: 1.0,
+				},
+			)
+			stop <- true
+		}
+	}()
+	return nil
+}

--- a/chipper/pkg/wirepod/preqs/knowledgegraph.go
+++ b/chipper/pkg/wirepod/preqs/knowledgegraph.go
@@ -72,7 +72,7 @@ func houndifyKG(req sr.SpeechRequest) string {
 func togetherRequest(transcribedText string) string {
 	sendString := "You are a helpful robot called Vector . You will be given a question asked by a user and you must provide the best answer you can. It may not be punctuated or spelled correctly. Keep the answer concise yet informative. Here is the question: " + "\\" + "\"" + transcribedText + "\\" + "\"" + " , Answer: "
 	url := "https://api.together.xyz/inference"
-    model := vars.APIConfig.Knowledge.Model
+	model := vars.APIConfig.Knowledge.Model
 	formData := `{
 "model": "` + model + `",
 "prompt": "` + sendString + `",
@@ -81,7 +81,7 @@ func togetherRequest(transcribedText string) string {
 "top_p": 1
 }`
 	logger.Println("Making request to Together API...")
-    logger.Println("Model is " + model)
+	logger.Println("Model is " + model)
 	req, _ := http.NewRequest("POST", url, bytes.NewBuffer([]byte(formData)))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+vars.APIConfig.Knowledge.Key)
@@ -92,30 +92,30 @@ func togetherRequest(transcribedText string) string {
 	}
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)
-    var togetherResponse map[string]any
+	var togetherResponse map[string]any
 	err = json.Unmarshal(body, &togetherResponse)
 	if err != nil {
 		return "Together API returned no response."
 	}
-    output := togetherResponse["output"].(map[string]any)
-    choice := output["choices"].([]any)
-    for _, val := range choice {
-        x := val.(map[string]any)
-        textResponse := x["text"].(string)
-        apiResponse := strings.TrimSuffix(textResponse, "</s>")
-	    logger.Println("Together response: " + apiResponse)
-        return apiResponse
-    }
-    // In case text is not present in result from API, return a string saying answer was not found
-    return "Answer was not found"
+	output := togetherResponse["output"].(map[string]any)
+	choice := output["choices"].([]any)
+	for _, val := range choice {
+		x := val.(map[string]any)
+		textResponse := x["text"].(string)
+		apiResponse := strings.TrimSuffix(textResponse, "</s>")
+		logger.Println("Together response: " + apiResponse)
+		return apiResponse
+	}
+	// In case text is not present in result from API, return a string saying answer was not found
+	return "Answer was not found"
 }
 
 func openaiRequest(transcribedText string) string {
-	sendString := "You are a helpful robot called " + vars.APIConfig.Knowledge.RobotName + ". You will be given a question asked by a user and you must provide the best answer you can. It may not be punctuated or spelled correctly. Keep the answer concise yet informative. Here is the question: " + "\\" + "\"" + transcribedText + "\\" + "\"" + " , Answer: "
+	sendString := "You are a helpful robot called " + vars.APIConfig.Knowledge.RobotName + ". You will be given a question asked by a user and you must provide the best answer you can. It may not be punctuated or spelled correctly as the STT model is small. The answer will be put through TTS, so it should be a speakable string. Keep the answer concise yet informative. Here is the question: " + "\\" + "\"" + transcribedText + "\\" + "\"" + " , Answer: "
 	logger.Println("Making request to OpenAI...")
 	url := "https://api.openai.com/v1/completions"
 	formData := `{
-"model": "text-davinci-003",
+"model": "gpt-3.5-turbo-instruct",
 "prompt": "` + sendString + `",
 "temperature": 0.7,
 "max_tokens": 256,

--- a/chipper/pkg/wirepod/sdkapp/jdocspinger.go
+++ b/chipper/pkg/wirepod/sdkapp/jdocspinger.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/digital-dream-labs/api/go/jdocspb"
 	"github.com/fforchino/vector-go-sdk/pkg/vectorpb"
 	"github.com/kercre123/chipper/pkg/logger"
 	"github.com/kercre123/chipper/pkg/vars"
@@ -80,7 +79,7 @@ func pingJdocs(target string) {
 	}
 	logger.Println("Successfully got jdocs from " + serial)
 	// write to file
-	var jdoc jdocspb.Jdoc
+	var jdoc vars.AJdoc
 	jdoc.DocVersion = resp.NamedJdocs[0].Doc.DocVersion
 	jdoc.FmtVersion = resp.NamedJdocs[0].Doc.FmtVersion
 	jdoc.ClientMetadata = resp.NamedJdocs[0].Doc.ClientMetadata

--- a/chipper/pkg/wirepod/sdkapp/server.go
+++ b/chipper/pkg/wirepod/sdkapp/server.go
@@ -236,6 +236,21 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		fmt.Fprintf(w, "success")
 		return
+	case r.URL.Path == "/api-sdk/add_face":
+		name := r.FormValue("name")
+		_, err := robot.Conn.AppIntent(
+			ctx,
+			&vectorpb.AppIntentRequest{
+				Intent: "intent_meet_victor",
+				Param:  name,
+			},
+		)
+		if err != nil {
+			fmt.Fprint(w, err.Error())
+			return
+		}
+		fmt.Fprintf(w, "success")
+		return
 	case r.URL.Path == "/api-sdk/mirror_mode":
 		enable := r.FormValue("enable")
 		if enable == "true" {

--- a/chipper/pkg/wirepod/speechrequest/speechrequest.go
+++ b/chipper/pkg/wirepod/speechrequest/speechrequest.go
@@ -18,7 +18,7 @@ import (
 
 var BotNum = 0
 
-var debugWriteFile bool = false
+var debugWriteFile bool = true
 var debugFile *os.File
 
 type SpeechRequest struct {

--- a/chipper/pkg/wirepod/speechrequest/speechrequest.go
+++ b/chipper/pkg/wirepod/speechrequest/speechrequest.go
@@ -26,6 +26,8 @@ type SpeechRequest struct {
 	Session        string
 	FirstReq       []byte
 	Stream         interface{}
+	IsKG           bool
+	IsIG           bool
 	MicData        []byte
 	DecodedMicData []byte
 	PrevLen        int
@@ -151,12 +153,14 @@ func ReqToSpeechRequest(req interface{}) SpeechRequest {
 		request.MicData = append(request.MicData, req1.FirstReq.InputAudio...)
 	} else if str, ok := req.(*vtt.KnowledgeGraphRequest); ok {
 		var req1 *vtt.KnowledgeGraphRequest = str
+		request.IsKG = true
 		request.Device = req1.Device
 		request.Session = req1.Session
 		request.Stream = req1.Stream
 		request.FirstReq = req1.FirstReq.InputAudio
 		request.MicData = append(request.MicData, req1.FirstReq.InputAudio...)
 	} else if str, ok := req.(*vtt.IntentGraphRequest); ok {
+		request.IsIG = true
 		var req1 *vtt.IntentGraphRequest = str
 		request.Device = req1.Device
 		request.Session = req1.Session

--- a/chipper/pkg/wirepod/speechrequest/speechrequest.go
+++ b/chipper/pkg/wirepod/speechrequest/speechrequest.go
@@ -107,7 +107,7 @@ func BytesToIntVAD(stream opus.OggStream, data []byte, die bool, isOpus bool) []
 // Uses VAD to detect when the user stops speaking
 func (req *SpeechRequest) DetectEndOfSpeech() bool {
 	// changes InactiveFrames and ActiveFrames in req
-	inactiveNumMax := 20
+	inactiveNumMax := 23
 	vad := req.VADInst
 	vad.SetMode(3)
 	for _, chunk := range SplitVAD(req.LastAudioChunk) {
@@ -123,7 +123,7 @@ func (req *SpeechRequest) DetectEndOfSpeech() bool {
 		} else {
 			req.InactiveFrames = req.InactiveFrames + 1
 		}
-		if req.InactiveFrames >= inactiveNumMax && req.ActiveFrames > 15 {
+		if req.InactiveFrames >= inactiveNumMax && req.ActiveFrames > 18 {
 			logger.Println("(Bot " + strconv.Itoa(req.BotNum) + ") End of speech detected.")
 			return true
 		}

--- a/chipper/pkg/wirepod/speechrequest/speechrequest.go
+++ b/chipper/pkg/wirepod/speechrequest/speechrequest.go
@@ -123,7 +123,7 @@ func (req *SpeechRequest) DetectEndOfSpeech() bool {
 		} else {
 			req.InactiveFrames = req.InactiveFrames + 1
 		}
-		if req.InactiveFrames >= inactiveNumMax && req.ActiveFrames > 20 {
+		if req.InactiveFrames >= inactiveNumMax && req.ActiveFrames > 15 {
 			logger.Println("(Bot " + strconv.Itoa(req.BotNum) + ") End of speech detected.")
 			return true
 		}

--- a/chipper/pkg/wirepod/speechrequest/speechrequest.go
+++ b/chipper/pkg/wirepod/speechrequest/speechrequest.go
@@ -178,7 +178,9 @@ func ReqToSpeechRequest(req interface{}) SpeechRequest {
 		request.OpusStream = &opus.OggStream{}
 		decodedFirstReq, _ := request.OpusStream.Decode(request.FirstReq)
 		request.FirstReq = decodedFirstReq
-		request.LastAudioChunk = decodedFirstReq
+		request.DecodedMicData = append(request.DecodedMicData, decodedFirstReq...)
+		request.LastAudioChunk = request.DecodedMicData[request.PrevLen:]
+		request.PrevLen = len(request.DecodedMicData)
 		request.IsOpus = true
 	}
 	return request

--- a/chipper/pkg/wirepod/speechrequest/speechrequest.go
+++ b/chipper/pkg/wirepod/speechrequest/speechrequest.go
@@ -178,6 +178,7 @@ func ReqToSpeechRequest(req interface{}) SpeechRequest {
 		request.OpusStream = &opus.OggStream{}
 		decodedFirstReq, _ := request.OpusStream.Decode(request.FirstReq)
 		request.FirstReq = decodedFirstReq
+		request.LastAudioChunk = decodedFirstReq
 		request.IsOpus = true
 	}
 	return request

--- a/chipper/pkg/wirepod/stt/vosk/Vosk.go
+++ b/chipper/pkg/wirepod/stt/vosk/Vosk.go
@@ -41,6 +41,8 @@ func Init() error {
 			sttLanguage = "en-US"
 		}
 		modelPath := "../vosk/models/" + sttLanguage + "/model"
+		Grammer = GetGrammerList(vars.APIConfig.STT.Language)
+		fmt.Println(Grammer)
 		logger.Println("Opening VOSK model (" + modelPath + ")")
 		aModel, err := vosk.NewModel(modelPath)
 		if err != nil {
@@ -49,8 +51,8 @@ func Init() error {
 		}
 		model = aModel
 		// just one rec for now. if more bots request later, those will get newly created and added to list of active recs
-		//aRecognizer, err := vosk.NewRecognizerGrm(aModel, 16000.0, Grammer)
-		aRecognizer, err := vosk.NewRecognizer(aModel, 16000.0)
+		aRecognizer, err := vosk.NewRecognizerGrm(aModel, 16000.0, Grammer)
+		//aRecognizer, err := vosk.NewRecognizer(aModel, 16000.0)
 		if err != nil {
 			log.Fatal(err)
 			return err

--- a/chipper/pkg/wirepod/stt/vosk/Vosk.go
+++ b/chipper/pkg/wirepod/stt/vosk/Vosk.go
@@ -41,8 +41,6 @@ func Init() error {
 			sttLanguage = "en-US"
 		}
 		modelPath := "../vosk/models/" + sttLanguage + "/model"
-		Grammer = GetGrammerList(vars.APIConfig.STT.Language)
-		fmt.Println(Grammer)
 		logger.Println("Opening VOSK model (" + modelPath + ")")
 		aModel, err := vosk.NewModel(modelPath)
 		if err != nil {
@@ -50,6 +48,8 @@ func Init() error {
 			return err
 		}
 		model = aModel
+		Grammer = GetGrammerList(vars.APIConfig.STT.Language)
+		fmt.Println(Grammer)
 		// just one rec for now. if more bots request later, those will get newly created and added to list of active recs
 		aRecognizer, err := vosk.NewRecognizerGrm(aModel, 16000.0, Grammer)
 		//aRecognizer, err := vosk.NewRecognizer(aModel, 16000.0)

--- a/chipper/pkg/wirepod/stt/vosk/Vosk.go
+++ b/chipper/pkg/wirepod/stt/vosk/Vosk.go
@@ -2,8 +2,10 @@ package wirepod_vosk
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"strconv"
+	"time"
 
 	vosk "github.com/alphacep/vosk-api/go"
 	"github.com/kercre123/chipper/pkg/logger"
@@ -14,10 +16,46 @@ import (
 var Name string = "vosk"
 
 var model *vosk.VoskModel
+var rec *vosk.VoskRecognizer
+var mainRecInUse bool
 var modelLoaded bool
+var Grammer string
+
+func removeDuplicates(slice []string) []string {
+	seen := make(map[string]bool)
+	result := []string{}
+	for _, val := range slice {
+		if _, ok := seen[val]; !ok {
+			seen[val] = true
+			result = append(result, val)
+		}
+	}
+	return result
+}
+
+func GetGrammerList(lang string) string {
+	var wordsList []string
+	var grammer string
+	for _, words := range vars.MatchListList {
+		for _, word := range words {
+			wordsList = append(wordsList, word)
+		}
+	}
+	wordsList = removeDuplicates(wordsList)
+	for i, word := range wordsList {
+		if i == len(wordsList)-1 {
+			grammer = grammer + `"` + word + `"`
+		} else {
+			grammer = grammer + `"` + word + `"` + ", "
+		}
+	}
+	grammer = "[" + grammer + "]"
+	return grammer
+}
 
 func Init() error {
 	if vars.APIConfig.PastInitialSetup {
+		Grammer = GetGrammerList(vars.APIConfig.STT.Language)
 		vosk.SetLogLevel(-1)
 		if modelLoaded {
 			logger.Println("A model was already loaded, freeing")
@@ -36,29 +74,53 @@ func Init() error {
 			return err
 		}
 		model = aModel
+		aRecognizer, err := vosk.NewRecognizerGrm(aModel, 16000.0, Grammer)
+		//aRecognizer, err := vosk.NewRecognizer(aModel, 16000.0)
+		if err != nil {
+			log.Fatal(err)
+			return err
+		}
+		rec = aRecognizer
 		modelLoaded = true
 		logger.Println("VOSK initiated successfully")
 	}
 	return nil
 }
 
+func setRecFalse() {
+	mainRecInUse = false
+}
+
 func STT(req sr.SpeechRequest) (string, error) {
 	logger.Println("(Bot " + strconv.Itoa(req.BotNum) + ", Vosk) Processing...")
 	speechIsDone := false
-	sampleRate := 16000.0
-	rec, err := vosk.NewRecognizer(model, sampleRate)
-	if err != nil {
-		log.Fatal(err)
+	var thisRec *vosk.VoskRecognizer
+	if mainRecInUse {
+		newRec, err := vosk.NewRecognizer(model, 16000.0)
+		if err != nil {
+			log.Fatal(err)
+		}
+		thisRec = newRec
+	} else {
+		mainRecInUse = true
+		defer setRecFalse()
+		fmt.Println("using main")
+		thisRec = rec
 	}
-	rec.SetWords(1)
-	rec.AcceptWaveform(req.FirstReq)
+	//sampleRate := 16000.0
+	// rec, err := vosk.NewRecognizerGrm(model, sampleRate, Grammer)
+	// if err != nil {
+	// 	log.Fatal(err)
+	// }
+	//thisRec.SetWords(2)
+	bTime := time.Now()
+	thisRec.AcceptWaveform(req.FirstReq)
 	for {
-		var chunk []byte
-		chunk, err = req.GetNextStreamChunk()
+		chunk, err := req.GetNextStreamChunk()
 		if err != nil {
 			return "", err
 		}
-		rec.AcceptWaveform(chunk)
+		thisRec.AcceptWaveform(chunk)
 		// has to be split into 320 []byte chunks for VAD
 		speechIsDone = req.DetectEndOfSpeech()
 		if speechIsDone {
@@ -66,7 +128,8 @@ func STT(req sr.SpeechRequest) (string, error) {
 		}
 	}
 	var jres map[string]interface{}
-	json.Unmarshal([]byte(rec.FinalResult()), &jres)
+	json.Unmarshal([]byte(thisRec.FinalResult()), &jres)
+	fmt.Println("Process took: ", time.Now().Sub(bTime))
 	transcribedText := jres["text"].(string)
 	logger.Println("Bot " + strconv.Itoa(req.BotNum) + " Transcribed text: " + transcribedText)
 	return transcribedText, nil

--- a/chipper/pkg/wirepod/stt/vosk/Vosk.go
+++ b/chipper/pkg/wirepod/stt/vosk/Vosk.go
@@ -71,6 +71,7 @@ func getRec() (*vosk.VoskRecognizer, int) {
 	for ind, rec := range recs {
 		if !rec.InUse {
 			recs[ind].InUse = true
+			fmt.Println("Returning already-created rec")
 			return recs[ind].Rec, ind
 		}
 	}
@@ -90,7 +91,7 @@ func STT(req sr.SpeechRequest) (string, error) {
 	speechIsDone := false
 	bTime := time.Now()
 	rec, recind := getRec()
-	//thisRec.SetWords(2)
+	rec.SetWords(0)
 	rec.AcceptWaveform(req.FirstReq)
 	for {
 		chunk, err := req.GetNextStreamChunk()

--- a/chipper/pkg/wirepod/stt/vosk/Vosk.go
+++ b/chipper/pkg/wirepod/stt/vosk/Vosk.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	vosk "github.com/alphacep/vosk-api/go"
 	"github.com/kercre123/chipper/pkg/logger"
@@ -119,9 +118,10 @@ func getRec(withGrm bool) (*vosk.VoskRecognizer, int) {
 func STT(req sr.SpeechRequest) (string, error) {
 	logger.Println("(Bot " + strconv.Itoa(req.BotNum) + ", Vosk) Processing...")
 	speechIsDone := false
-	bTime := time.Now()
 	var withGrm bool
 	if vars.APIConfig.Knowledge.IntentGraph || req.IsKG {
+		withGrm = false
+	} else {
 		withGrm = true
 	}
 	rec, recind := getRec(withGrm)
@@ -146,7 +146,6 @@ func STT(req sr.SpeechRequest) (string, error) {
 	} else {
 		gpRecs[recind].InUse = false
 	}
-	fmt.Println("Process took: ", time.Now().Sub(bTime))
 	transcribedText := jres["text"].(string)
 	logger.Println("Bot " + strconv.Itoa(req.BotNum) + " Transcribed text: " + transcribedText)
 	return transcribedText, nil

--- a/chipper/pkg/wirepod/stt/vosk/Vosk.go
+++ b/chipper/pkg/wirepod/stt/vosk/Vosk.go
@@ -161,8 +161,10 @@ func STT(req sr.SpeechRequest) (string, error) {
 	speechIsDone := false
 	var withGrm bool
 	if vars.APIConfig.Knowledge.IntentGraph || req.IsKG {
+		logger.Println("Using general recognizer")
 		withGrm = false
 	} else {
+		logger.Println("Using grammer-optimized recognizer")
 		withGrm = true
 	}
 	rec, recind := getRec(withGrm)

--- a/chipper/pkg/wirepod/stt/vosk/Vosk.go
+++ b/chipper/pkg/wirepod/stt/vosk/Vosk.go
@@ -145,6 +145,7 @@ func getRec(withGrm bool) (*vosk.VoskRecognizer, int) {
 			}
 		}
 	}
+	recsmu.Unlock()
 	var newrec ARec
 	var newRec *vosk.VoskRecognizer
 	var err error
@@ -158,6 +159,7 @@ func getRec(withGrm bool) (*vosk.VoskRecognizer, int) {
 		log.Fatal(err)
 	}
 	newrec.Rec = newRec
+	recsmu.Lock()
 	if withGrm {
 		grmRecs = append(grmRecs, newrec)
 		return grmRecs[len(grmRecs)-1].Rec, len(grmRecs) - 1
@@ -171,7 +173,7 @@ func STT(req sr.SpeechRequest) (string, error) {
 	logger.Println("(Bot " + strconv.Itoa(req.BotNum) + ", Vosk) Processing...")
 	speechIsDone := false
 	var withGrm bool
-	if vars.APIConfig.Knowledge.IntentGraph || req.IsKG || !GrammerEnable {
+	if (vars.APIConfig.Knowledge.IntentGraph || req.IsKG) || !GrammerEnable {
 		logger.Println("Using general recognizer")
 		withGrm = false
 	} else {
@@ -179,7 +181,7 @@ func STT(req sr.SpeechRequest) (string, error) {
 		withGrm = true
 	}
 	rec, recind := getRec(withGrm)
-	rec.SetWords(0)
+	rec.SetWords(1)
 	rec.AcceptWaveform(req.FirstReq)
 	req.DetectEndOfSpeech()
 	for {

--- a/chipper/pkg/wirepod/stt/vosk/Vosk.go
+++ b/chipper/pkg/wirepod/stt/vosk/Vosk.go
@@ -12,6 +12,7 @@ import (
 	vosk "github.com/alphacep/vosk-api/go"
 	"github.com/kercre123/chipper/pkg/logger"
 	"github.com/kercre123/chipper/pkg/vars"
+	"github.com/kercre123/chipper/pkg/wirepod/localization"
 	sr "github.com/kercre123/chipper/pkg/wirepod/speechrequest"
 )
 
@@ -133,6 +134,7 @@ func removeDuplicates(slice []string) []string {
 func GetGrammerList(lang string) string {
 	var wordsList []string
 	var grammer string
+	// add words in intent json
 	for _, words := range vars.MatchListList {
 		for _, word := range words {
 			wors := strings.Split(word, " ")
@@ -144,6 +146,30 @@ func GetGrammerList(lang string) string {
 			}
 		}
 	}
+	// add words in localization
+	for _, str := range localization.ALL_STR {
+		text := localization.GetText(str)
+		wors := strings.Split(text, " ")
+		for _, wor := range wors {
+			found := model.FindWord(wor)
+			if found != -1 {
+				wordsList = append(wordsList, wor)
+			}
+		}
+	}
+	// add custom intent matches
+	for _, intent := range vars.CustomIntents {
+		for _, utterance := range intent.Utterances {
+			wors := strings.Split(utterance, " ")
+			for _, wor := range wors {
+				found := model.FindWord(wor)
+				if found != -1 {
+					wordsList = append(wordsList, wor)
+				}
+			}
+		}
+	}
+
 	wordsList = removeDuplicates(wordsList)
 	for i, word := range wordsList {
 		if i == len(wordsList)-1 {

--- a/chipper/pkg/wirepod/stt/vosk/Vosk.go
+++ b/chipper/pkg/wirepod/stt/vosk/Vosk.go
@@ -170,6 +170,7 @@ func STT(req sr.SpeechRequest) (string, error) {
 	rec, recind := getRec(withGrm)
 	rec.SetWords(0)
 	rec.AcceptWaveform(req.FirstReq)
+	req.DetectEndOfSpeech()
 	for {
 		chunk, err := req.GetNextStreamChunk()
 		if err != nil {

--- a/chipper/pkg/wirepod/stt/vosk/Vosk.go
+++ b/chipper/pkg/wirepod/stt/vosk/Vosk.go
@@ -74,8 +74,8 @@ func Init() error {
 			return err
 		}
 		model = aModel
-		aRecognizer, err := vosk.NewRecognizerGrm(aModel, 16000.0, Grammer)
-		//aRecognizer, err := vosk.NewRecognizer(aModel, 16000.0)
+		//aRecognizer, err := vosk.NewRecognizerGrm(aModel, 16000.0, Grammer)
+		aRecognizer, err := vosk.NewRecognizer(aModel, 16000.0)
 		if err != nil {
 			log.Fatal(err)
 			return err

--- a/chipper/pkg/wirepod/stt/vosk/context.go
+++ b/chipper/pkg/wirepod/stt/vosk/context.go
@@ -1,0 +1,80 @@
+package wirepod_vosk
+
+import (
+	"strings"
+
+	"github.com/kercre123/chipper/pkg/vars"
+	"github.com/kercre123/chipper/pkg/wirepod/localization"
+)
+
+var NumbersEN_US []string = []string{"one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten", "eleven", "twelve", "thirteen", "fourteen", "fifteen", "sixteen", "seventeen", "eighteen", "nineteen", "twenty", "thirty", "forty", "fifty", "sixty", "seventy", "eighty", "ninety", "hundred", "seconds", "minutes", "hours", "minute", "second", "hour"}
+
+func removeDuplicates(slice []string) []string {
+	seen := make(map[string]bool)
+	result := []string{}
+	for _, val := range slice {
+		if _, ok := seen[val]; !ok {
+			seen[val] = true
+			result = append(result, val)
+		}
+	}
+	return result
+}
+
+func GetGrammerList(lang string) string {
+	var wordsList []string
+	var grammer string
+	// add words in intent json
+	for _, words := range vars.MatchListList {
+		for _, word := range words {
+			wors := strings.Split(word, " ")
+			for _, wor := range wors {
+				found := model.FindWord(wor)
+				if found != -1 {
+					wordsList = append(wordsList, wor)
+				}
+			}
+		}
+	}
+	// add words in localization
+	for _, str := range localization.ALL_STR {
+		text := localization.GetText(str)
+		wors := strings.Split(text, " ")
+		for _, wor := range wors {
+			found := model.FindWord(wor)
+			if found != -1 {
+				wordsList = append(wordsList, wor)
+			}
+		}
+	}
+	// add custom intent matches
+	for _, intent := range vars.CustomIntents {
+		for _, utterance := range intent.Utterances {
+			wors := strings.Split(utterance, " ")
+			for _, wor := range wors {
+				found := model.FindWord(wor)
+				if found != -1 {
+					wordsList = append(wordsList, wor)
+				}
+			}
+		}
+	}
+	// add numbers
+	for _, wor := range NumbersEN_US {
+		found := model.FindWord(wor)
+		if found != -1 {
+			wordsList = append(wordsList, wor)
+		}
+	}
+
+	wordsList = removeDuplicates(wordsList)
+	for i, word := range wordsList {
+		if i == len(wordsList)-1 {
+			grammer = grammer + `"` + word + `"`
+		} else {
+			grammer = grammer + `"` + word + `"` + ", "
+		}
+	}
+	grammer = "[" + grammer + "]"
+	return grammer
+}

--- a/chipper/pkg/wirepod/stt/vosk/context.go
+++ b/chipper/pkg/wirepod/stt/vosk/context.go
@@ -9,18 +9,17 @@ import (
 
 var NumbersEN_US []string = []string{"one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten", "eleven", "twelve", "thirteen", "fourteen", "fifteen", "sixteen", "seventeen", "eighteen", "nineteen", "twenty", "thirty", "forty", "fifty", "sixty", "seventy", "eighty", "ninety", "hundred", "seconds", "minutes", "hours", "minute", "second", "hour"}
 
-func removeDuplicates(slice []string) []string {
-	seen := make(map[string]bool)
-	result := []string{}
-	for _, val := range slice {
-		if _, ok := seen[val]; !ok {
-			seen[val] = true
-			result = append(result, val)
+func removeDuplicates(strings []string) []string {
+	occurred := map[string]bool{}
+	var result []string
+	for _, str := range strings {
+		if !occurred[str] {
+			result = append(result, str)
+			occurred[str] = true
 		}
 	}
 	return result
 }
-
 func GetGrammerList(lang string) string {
 	var wordsList []string
 	var grammer string

--- a/chipper/pkg/wirepod/ttr/bcontrol.go
+++ b/chipper/pkg/wirepod/ttr/bcontrol.go
@@ -1,0 +1,81 @@
+package wirepod_ttr
+
+import (
+	"context"
+	"log"
+
+	"github.com/fforchino/vector-go-sdk/pkg/vector"
+	"github.com/fforchino/vector-go-sdk/pkg/vectorpb"
+)
+
+func sayText(robot *vector.Vector, text string) {
+	controlRequest := &vectorpb.BehaviorControlRequest{
+		RequestType: &vectorpb.BehaviorControlRequest_ControlRequest{
+			ControlRequest: &vectorpb.ControlRequest{
+				Priority: vectorpb.ControlRequest_OVERRIDE_BEHAVIORS,
+			},
+		},
+	}
+	go func() {
+		start := make(chan bool)
+		stop := make(chan bool)
+		go func() {
+			// * begin - modified from official vector-go-sdk
+			r, err := robot.Conn.BehaviorControl(
+				context.Background(),
+			)
+			if err != nil {
+				log.Println(err)
+				return
+			}
+
+			if err := r.Send(controlRequest); err != nil {
+				log.Println(err)
+				return
+			}
+
+			for {
+				ctrlresp, err := r.Recv()
+				if err != nil {
+					log.Println(err)
+					return
+				}
+				if ctrlresp.GetControlGrantedResponse() != nil {
+					start <- true
+					break
+				}
+			}
+
+			for {
+				select {
+				case <-stop:
+					if err := r.Send(
+						&vectorpb.BehaviorControlRequest{
+							RequestType: &vectorpb.BehaviorControlRequest_ControlRelease{
+								ControlRelease: &vectorpb.ControlRelease{},
+							},
+						},
+					); err != nil {
+						log.Println(err)
+						return
+					}
+					return
+				default:
+					continue
+				}
+			}
+			// * end - modified from official vector-go-sdk
+		}()
+		for range start {
+			robot.Conn.SayText(
+				context.Background(),
+				&vectorpb.SayTextRequest{
+					Text:           text,
+					UseVectorVoice: true,
+					DurationScalar: 1.0,
+				},
+			)
+			stop <- true
+		}
+	}()
+}

--- a/chipper/pkg/wirepod/ttr/intentparam.go
+++ b/chipper/pkg/wirepod/ttr/intentparam.go
@@ -168,7 +168,7 @@ func ParamChecker(req interface{}, intent string, speechText string, justThisBot
 		}
 		intentParams = map[string]string{intentParam: intentParamValue}
 	} else if strings.Contains(intent, "intent_names_username_extend") {
-		if vars.APIConfig.STT.Service == "vosk" && !vars.APIConfig.Knowledge.IntentGraph {
+		if vars.VoskGrammerEnable {
 			var guid string
 			var target string
 			matched := false

--- a/chipper/pkg/wirepod/ttr/intentparam.go
+++ b/chipper/pkg/wirepod/ttr/intentparam.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/fforchino/vector-go-sdk/pkg/vector"
 	"github.com/kercre123/chipper/pkg/logger"
 	"github.com/kercre123/chipper/pkg/vars"
 	lcztn "github.com/kercre123/chipper/pkg/wirepod/localization"
@@ -167,6 +168,29 @@ func ParamChecker(req interface{}, intent string, speechText string, justThisBot
 		}
 		intentParams = map[string]string{intentParam: intentParamValue}
 	} else if strings.Contains(intent, "intent_names_username_extend") {
+		if vars.APIConfig.STT.Service == "vosk" && !vars.APIConfig.Knowledge.IntentGraph {
+			var guid string
+			var target string
+			matched := false
+			for _, bot := range vars.BotInfo.Robots {
+				if botSerial == bot.Esn {
+					guid = bot.GUID
+					target = bot.IPAddress + ":443"
+					matched = true
+					break
+				}
+			}
+			if matched {
+				vec, err := vector.New(vector.WithSerialNo(botSerial), vector.WithToken(guid), vector.WithTarget(target))
+				if err != nil {
+					logger.Println("error connecting to vector:", err)
+				} else {
+					sayText(vec, "You must add a face in the web interface. It cannot be done via voice by default.")
+				}
+			}
+			logger.Println("You must add a face via the web interface (Bot Settings -> Connect -> Faces).")
+			logger.LogUI("You must add a face via the web interface (Bot Settings -> Connect -> Faces).")
+		}
 		var username string
 		var nameSplitter string = ""
 		isParam = true

--- a/chipper/webroot/sdkapp/js/faces.js
+++ b/chipper/webroot/sdkapp/js/faces.js
@@ -77,6 +77,17 @@ function renameFace() {
   }
 }
 
+function addFace() {
+  var name = document.getElementById("faceInput").value;
+  if (name == "") {
+    alert("You must enter a name.")
+    return
+  } else {
+    fetch("/api-sdk/add_face?serial=" + esn + "&name=" + name)
+      .then (function(){alert("Request successfully sent. Vector should now be finding a face to scan."); refreshFaceList()})
+  }
+}
+
 function deleteFace() {
   if (!areThereFaces) {
     window.alert("You must register a face first.")

--- a/chipper/webroot/sdkapp/settings.html
+++ b/chipper/webroot/sdkapp/settings.html
@@ -97,6 +97,8 @@
 
       <div id="section-face" class="toggleable-section" style="display:none;">
         <h2 class="center">Face Manager</h2>
+
+        <h3 class="center">Modify existing faces:</h3>
         <p class="center">Choose the face you would like to modify.</p>
         <div class="center">
           <select id="faceList" name="faceList"></select>
@@ -109,6 +111,15 @@
             <button onclick="deleteFace()" type="submit">Delete</button>
             <button onclick="renameFace()" type="submit">Rename</button>
           </div>
+        </div>
+
+        <h3 class="center">Add a new face:</h3>
+        <p class="center">Enter a name you'd like to add:</p>
+        <div class="center">
+          <input class="tinput" id="faceInput" name="faceInput" type="text" placeholder="Put name here">
+          </div>
+          <div class="center">
+          <button onclick="addFace()">Add Face</button>
         </div>
         <hr>
       </div>


### PR DESCRIPTION
- When a new VOSK recognizer is created, save it for future use
- On a jdocs read/write request, the IP for the bot in botSdkInfo will get updated if it is different
- Add grammer-optimizations to VOSK. These can be enabled by adding `VOSK_WITH_GRAMMER=true` in the source.sh file then restarting wire-pod
- Fix some little things in the web interface: switching intent graph on/off works now, you can now add faces in the Face Manager menu of the Bot Settings interface
- Testcode for 1.6-1.7 intent-graph functionality
- VAD touchups
- Code now fully passes staticcheck (jdocs contains a sync.Mutex and they were copied in a few spots, which it didn't like)

Saving VOSK recognizers for future use increases performance on SBCs like the Raspberry Pi. Grammer also increases it (and makes it usable on even the RPi3b+), but it limits your words so intent-graph wouldn't work. When you enable the grammer optimizations, you will also need to disable intent-graph in order for it to work. The optimizations limit the amount of words the model has to process to just the ones which would match to an intent, which makes it a whole lot faster, but means you can't ask general questions like you would want to with the knowledge graph API.

When grammer optimizations are enabled, a general purpose recognizer is still created, so you can still say "I have a question" and that request will use the general recognizer and functionality will not be limited in any way. Only intent-graph will truly be affected. So I still think it is fine to enable it for normal operation.