### PR TITLE
Added docker, compose and volumes for easy local hosting on any machine

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,98 @@
+name: Docker
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  schedule:
+    - cron: '25 22 * * *'
+  push:
+    branches: [ "main" ]
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@6e04d228eb30da1757ee4e1dd75a0ec73a653e06 #v3.1.1
+        with:
+          cosign-release: 'v2.1.1'
+
+      # Set up BuildKit Docker container builder to be able to build
+      # multi-platform images and export cache
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}

--- a/README.md
+++ b/README.md
@@ -12,6 +12,29 @@ The installation guide exists on the wiki: [Installation guide](https://github.c
 
 Check out the [wiki](https://github.com/kercre123/wire-pod/wiki) for more information on what wire-pod is, a guide on how to install wire-pod, troubleshooting, how to develop for it, and for some generally helpful tips.
 
+## Docker compose
+
+`
+version: '3.8'
+services:
+  wire-pod:
+    image: ghcr.io/zippy-boy/wire-pod:main
+    restart: unless-stopped
+    ports:
+      - 443:443
+      - 8080:8080
+      - 80:80
+      - 8084:8084
+    volumes:
+      - wire-pod-data:/app/chipper/
+      - wire-pod-model:/app/vosk/
+volumes:
+  wire-pod-data:
+    driver: local
+  wire-pod-model:
+    driver: local
+`
+
 ## Donate
 
 If you want to :P

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,18 @@
+version: '3.8'
+services:
+  wire-pod:
+    image: ghcr.io/zippy-boy/wire-pod:main
+    restart: unless-stopped
+    ports:
+      - 443:443
+      - 8080:8080
+      - 80:80
+      - 8084:8084
+    volumes:
+      - wire-pod-data:/app/chipper/
+      - wire-pod-model:/app/vosk/
+volumes:
+  wire-pod-data:
+    driver: local
+  wire-pod-model:
+    driver: local

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,7 @@
 version: '3.8'
 services:
   wire-pod:
+    hostname: escapepod
     image: ghcr.io/zippy-boy/wire-pod:main
     restart: unless-stopped
     ports:

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu
+
+WORKDIR /app
+COPY . /app
+
+RUN chmod +x /app/setup.sh && apt-get update && apt-get install -y dos2unix && dos2unix /app/setup.sh
+
+RUN ["/bin/sh", "-c", "STT=vosk ./setup.sh"]
+
+RUN chmod +x /app/chipper/start.sh && dos2unix /app/chipper/start.sh
+
+CMD ["/bin/sh", "-c", "./chipper/start.sh"]

--- a/dockerfile
+++ b/dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu
 WORKDIR /app
 COPY . /app
 
-RUN chmod +x /app/setup.sh && apt-get update && apt-get install -y dos2unix && dos2unix /app/setup.sh
+RUN chmod +x /app/setup.sh && apt-get update && apt-get install -y dos2unix && dos2unix /app/setup.sh && apt install avahi-daemon avahi-autoipd
 
 RUN ["/bin/sh", "-c", "STT=vosk ./setup.sh"]
 


### PR DESCRIPTION
I have a portainer server for local hosting apps. I though that this would be a good inclusion so i could manage and easily update and deploy it when ever i want. (easy monitoring too). If you do accept this pull request then you would have to change the `    image: ghcr.io/zippy-boy/wire-pod:main` in the docker compose.yaml file to have your github name instead of mine, but that's all you would need to do. Thanks for reading though :)