### PR TITLE
Update compose.yaml. Left host network in for development by accident. 

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -4,7 +4,6 @@ services:
     hostname: escapepod
     image: ghcr.io/kercre123/wire-pod:main
     restart: unless-stopped
-    network_mode: host
     ports:
       - 443:443
       - 8080:8080


### PR DESCRIPTION
The host network won't allow ports to be exposed on the container or may be overridden by other programs. Sorry bout this. 