### PR TITLE
 Query escape location to prevent bad request

### DIFF
--- a/chipper/pkg/wirepod/ttr/weather.go
+++ b/chipper/pkg/wirepod/ttr/weather.go
@@ -247,7 +247,7 @@ func getWeather(location string, botUnits string, hoursFromNow int) (string, str
 		} else if weatherAPIProvider == "openweathermap.org" {
 			// First use geocoding api to convert location into coordinates
 			// E.G. http://api.openweathermap.org/geo/1.0/direct?q={city name},{state code},{country code}&limit={limit}&appid={API key}
-			url := "http://api.openweathermap.org/geo/1.0/direct?q=" + location + "&limit=1&appid=" + weatherAPIKey
+			url := "http://api.openweathermap.org/geo/1.0/direct?q=" + url.QueryEscape(location) + "&limit=1&appid=" + weatherAPIKey
 			resp, err := http.Get(url)
 			if err != nil {
 				logger.Println(err)


### PR DESCRIPTION
For example 
http://api.openweathermap.org/geo/1.0/direct?q=Oklahoma City, Oklahoma&limit=1&appid=8fb....

Will result in a body response:
```<html>
<head><title>400 Bad Request</title></head>
<body>
<center><h1>400 Bad Request</h1></center>
<hr><center>openresty</center>
</body>
</html>
```
Because the spaces in the location name