### PR TITLE
Optimizations for running in a container based via compose/Dockerfile in repo roo

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,36 @@
+# Include any files or directories that you don't want to be copied to your
+# container here (e.g., local build artifacts, temporary files, etc.).
+#
+# For more help, visit the .dockerignore file reference guide at
+# https://docs.docker.com/go/build-context-dockerignore/
+#
+# TODO assess if anything that is ignored here needs to be removed... this is from `docker init` and select general type
+
+**/.DS_Store
+**/__pycache__
+**/.venv
+**/.classpath
+**/.dockerignore
+**/.env
+**/.git
+**/.gitignore
+**/.project
+**/.settings
+**/.toolstarget
+**/.vs
+**/.vscode
+**/*.*proj.user
+**/*.dbmdl
+**/*.jfm
+**/bin
+**/charts
+**/docker-compose*
+**/compose.y*ml
+**/Dockerfile*
+**/node_modules
+**/npm-debug.log
+**/obj
+**/secrets.dev.yaml
+**/values.dev.yaml
+LICENSE
+README.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,7 @@
+# manual ignores:
+**/.github
+**/dockerfile*
+
 # Include any files or directories that you don't want to be copied to your
 # container here (e.g., local build artifacts, temporary files, etc.).
 #

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,6 @@
 # For more help, visit the .dockerignore file reference guide at
 # https://docs.docker.com/go/build-context-dockerignore/
 #
-# TODO assess if anything that is ignored here needs to be removed... this is from `docker init` and select general type
 
 **/.DS_Store
 **/__pycache__

--- a/chipper/start.sh
+++ b/chipper/start.sh
@@ -41,25 +41,25 @@ if [[ ${STT_SERVICE} == "leopard" ]]; then
     else
         /usr/local/go/bin/go run -tags $GOTAGS cmd/leopard/main.go
     fi
-    elif [[ ${STT_SERVICE} == "rhino" ]]; then
+elif [[ ${STT_SERVICE} == "rhino" ]]; then
     if [[ -f ./chipper ]]; then
         ./chipper
     else
         /usr/local/go/bin/go run -tags $GOTAGS cmd/experimental/rhino/main.go
     fi
-    elif [[ ${STT_SERVICE} == "houndify" ]]; then
+elif [[ ${STT_SERVICE} == "houndify" ]]; then
     if [[ -f ./chipper ]]; then
         ./chipper
     else
         /usr/local/go/bin/go run -tags $GOTAGS cmd/experimental/houndify/main.go
     fi
-    elif [[ ${STT_SERVICE} == "whisper" ]]; then
+elif [[ ${STT_SERVICE} == "whisper" ]]; then
     if [[ -f ./chipper ]]; then
         ./chipper
     else
         /usr/local/go/bin/go run -tags $GOTAGS cmd/experimental/whisper/main.go
     fi
-    elif [[ ${STT_SERVICE} == "whisper.cpp" ]]; then
+elif [[ ${STT_SERVICE} == "whisper.cpp" ]]; then
     if [[ -f ./chipper ]]; then
         export C_INCLUDE_PATH="../whisper.cpp"
         export LIBRARY_PATH="../whisper.cpp"
@@ -80,7 +80,7 @@ if [[ ${STT_SERVICE} == "leopard" ]]; then
             /usr/local/go/bin/go run -tags $GOTAGS cmd/experimental/whisper.cpp/main.go
         fi
     fi
-    elif [[ ${STT_SERVICE} == "vosk" ]]; then
+elif [[ ${STT_SERVICE} == "vosk" ]]; then
     if [[ -f ./chipper ]]; then
         export CGO_ENABLED=1
         export CGO_CFLAGS="-I/root/.vosk/libvosk"

--- a/chipper/start.sh
+++ b/chipper/start.sh
@@ -93,7 +93,13 @@ elif [[ ${STT_SERVICE} == "vosk" ]]; then
         export CGO_CFLAGS="-I/root/.vosk/libvosk"
         export CGO_LDFLAGS="-L /root/.vosk/libvosk -lvosk -ldl -lpthread"
         export LD_LIBRARY_PATH="/root/.vosk/libvosk:$LD_LIBRARY_PATH"
-        /usr/local/go/bin/go run -tags $GOTAGS -exec "env DYLD_LIBRARY_PATH=$HOME/.vosk/libvosk" cmd/vosk/main.go
+        # GO_COMMAND=="build"
+        if [[ ${GO_COMMAND} == "build" ]]; then
+            # TLDR to download go deps... can I just run this in the Dockerfile? when I copy in go.mod/sum?
+            /usr/local/go/bin/go $GO_COMMAND -tags $GOTAGS -o chipper cmd/vosk/main.go
+        else
+            /usr/local/go/bin/go $GO_COMMAND -tags $GOTAGS -exec "env DYLD_LIBRARY_PATH=$HOME/.vosk/libvosk" cmd/vosk/main.go
+        fi
     fi
 else
     if [[ -f ./chipper ]]; then

--- a/chipper/start.sh
+++ b/chipper/start.sh
@@ -93,7 +93,6 @@ elif [[ ${STT_SERVICE} == "vosk" ]]; then
         export CGO_CFLAGS="-I/root/.vosk/libvosk"
         export CGO_LDFLAGS="-L /root/.vosk/libvosk -lvosk -ldl -lpthread"
         export LD_LIBRARY_PATH="/root/.vosk/libvosk:$LD_LIBRARY_PATH"
-        # GO_COMMAND=="build"
         if [[ ${GO_COMMAND} == "build" ]]; then
             # TLDR to download go deps... can I just run this in the Dockerfile? when I copy in go.mod/sum?
             /usr/local/go/bin/go $GO_COMMAND -tags $GOTAGS -o chipper cmd/vosk/main.go

--- a/chipper/start.sh
+++ b/chipper/start.sh
@@ -93,12 +93,7 @@ elif [[ ${STT_SERVICE} == "vosk" ]]; then
         export CGO_CFLAGS="-I/root/.vosk/libvosk"
         export CGO_LDFLAGS="-L /root/.vosk/libvosk -lvosk -ldl -lpthread"
         export LD_LIBRARY_PATH="/root/.vosk/libvosk:$LD_LIBRARY_PATH"
-        if [[ ${GO_COMMAND} == "build" ]]; then
-            # TLDR to download go deps... can I just run this in the Dockerfile? when I copy in go.mod/sum?
-            /usr/local/go/bin/go $GO_COMMAND -tags $GOTAGS -o chipper cmd/vosk/main.go
-        else
-            /usr/local/go/bin/go $GO_COMMAND -tags $GOTAGS -exec "env DYLD_LIBRARY_PATH=$HOME/.vosk/libvosk" cmd/vosk/main.go
-        fi
+        /usr/local/go/bin/go run -tags $GOTAGS -exec "env DYLD_LIBRARY_PATH=$HOME/.vosk/libvosk" cmd/vosk/main.go
     fi
 else
     if [[ -f ./chipper ]]; then

--- a/chipper/start.sh
+++ b/chipper/start.sh
@@ -93,7 +93,11 @@ elif [[ ${STT_SERVICE} == "vosk" ]]; then
         export CGO_CFLAGS="-I/root/.vosk/libvosk"
         export CGO_LDFLAGS="-L /root/.vosk/libvosk -lvosk -ldl -lpthread"
         export LD_LIBRARY_PATH="/root/.vosk/libvosk:$LD_LIBRARY_PATH"
-        /usr/local/go/bin/go run -tags $GOTAGS -exec "env DYLD_LIBRARY_PATH=$HOME/.vosk/libvosk" cmd/vosk/main.go
+        if [[ ${DO_GO_BUILD} == "true" ]]; then
+            /usr/local/go/bin/go build -tags $GOTAGS -o chipper cmd/vosk/main.go
+        else
+            /usr/local/go/bin/go run -tags $GOTAGS -exec "env DYLD_LIBRARY_PATH=$HOME/.vosk/libvosk" cmd/vosk/main.go
+        fi
     fi
 else
     if [[ -f ./chipper ]]; then

--- a/chipper/start.sh
+++ b/chipper/start.sh
@@ -25,6 +25,7 @@ if [[ ! -f ./source.sh ]]; then
     exit 0
 fi
 
+# sets env vars: (i.e. STT_SERVICE)
 source source.sh
 
 # set go tags

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,6 +2,7 @@ services:
   wire-pod:
     hostname: escapepod
     build: .
+    network_mode: host
     image: ghcr.io/kercre123/wire-pod:main
     restart: unless-stopped
     ports:

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,6 +3,7 @@ services:
     hostname: escapepod
     build: .
     network_mode: host
+    platform: linux/arm64
     image: ghcr.io/kercre123/wire-pod:main
     restart: unless-stopped
     ports:

--- a/compose.yaml
+++ b/compose.yaml
@@ -22,7 +22,7 @@ services:
       #   A /chipper/jdocs/botSdkInfo.json # stores vector IP, etc
       #   A /chipper/jdocs/jdocs.json
       #   A /vosk # vosk model extracted here.. would like to move this into image build too (very early on)
-      # TODO this is a problem to use a volume for /chipper in terms of updates, can we split out just the part that has the database we need to preserve and not cache the codebase? otherwise once created it will never update if image contents change...  admittedly the compose file here does not appear designed for the use case of updating at all (neither via a volume nor via the image...?)
+      # TODO this is a problem to use a volume for /chipper in terms of updates, can we split out just the part that has the database we need to preserve and not cache the codebase? otherwise once created it will never update if image contents change...  admittedly the compose file here does not appear designed for the use case of updating at all (neither via a volume nor via the image...?) ... appears that update.sh uses git to pull latest code?! from this repo... so my dockerignore on .git is not gonna be so helpful then :)
       #  /root/.anki_vector/* ??? is this the path? if so make a volume for this
       # - wire-pod-data:/chipper/
       - wire-pod-model:/vosk/

--- a/compose.yaml
+++ b/compose.yaml
@@ -16,7 +16,7 @@ services:
       # - wire-pod-data:/chipper/
       - wire-pod-model:/vosk/
 volumes:
-  wire-pod-data:
-    driver: local
+  # wire-pod-data:
+  #   driver: local
   wire-pod-model:
     driver: local

--- a/compose.yaml
+++ b/compose.yaml
@@ -12,6 +12,16 @@ services:
       - 80:80
       - 8084:8084
     volumes:
+      # FYI after setup new server and join vector to it... diff shows only these changed files:
+      # $ docker container diff wire-pod-wire-pod-run-b2a5f3d4bf75
+      #   A /certs
+      #   A /certs/server_config.json
+      #   C /chipper
+      #   A /chipper/apiConfig.json
+      #   C /chipper/jdocs
+      #   A /chipper/jdocs/botSdkInfo.json
+      #   A /chipper/jdocs/jdocs.json
+      #   A /vosk
       # TODO this is a problem to use a volume for /chipper in terms of updates, can we split out just the part that has the database we need to preserve and not cache the codebase? otherwise once created it will never update if image contents change...  admittedly the compose file here does not appear designed for the use case of updating at all (neither via a volume nor via the image...?)
       #  /root/.anki_vector/* ??? is this the path? if so make a volume for this
       # - wire-pod-data:/chipper/

--- a/compose.yaml
+++ b/compose.yaml
@@ -13,6 +13,7 @@ services:
       - 8084:8084
     volumes:
       # TODO this is a problem to use a volume for /chipper in terms of updates, can we split out just the part that has the database we need to preserve and not cache the codebase? otherwise once created it will never update if image contents change...  admittedly the compose file here does not appear designed for the use case of updating at all (neither via a volume nor via the image...?)
+      #  /root/.anki_vector/* ??? is this the path? if so make a volume for this
       # - wire-pod-data:/chipper/
       - wire-pod-model:/vosk/
 volumes:

--- a/compose.yaml
+++ b/compose.yaml
@@ -12,7 +12,8 @@ services:
       - 80:80
       - 8084:8084
     volumes:
-      - wire-pod-data:/chipper/
+      # get rid of caching the chipper dir, this should be baked into the image IMHO, and is a problem b/c rebuilding image and copying changes into /chipper is masked by an already UP'd volume mount...
+      # - wire-pod-data:/chipper/
       - wire-pod-model:/vosk/
 volumes:
   wire-pod-data:

--- a/compose.yaml
+++ b/compose.yaml
@@ -17,11 +17,11 @@ services:
       #   A /certs
       #   A /certs/server_config.json
       #   C /chipper
-      #   A /chipper/apiConfig.json
+      #   A /chipper/apiConfig.json    # stores config for first Submit Settings page (i.e. openai api key, weather api key, etc.)
       #   C /chipper/jdocs
-      #   A /chipper/jdocs/botSdkInfo.json
+      #   A /chipper/jdocs/botSdkInfo.json # stores vector IP, etc
       #   A /chipper/jdocs/jdocs.json
-      #   A /vosk
+      #   A /vosk # vosk model extracted here.. would like to move this into image build too (very early on)
       # TODO this is a problem to use a volume for /chipper in terms of updates, can we split out just the part that has the database we need to preserve and not cache the codebase? otherwise once created it will never update if image contents change...  admittedly the compose file here does not appear designed for the use case of updating at all (neither via a volume nor via the image...?)
       #  /root/.anki_vector/* ??? is this the path? if so make a volume for this
       # - wire-pod-data:/chipper/

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,7 +2,7 @@ services:
   wire-pod:
     hostname: escapepod
     build: .
-    network_mode: host
+    network_mode: host # b/c mDNS escapepod.local broadcast... why use mDNS? people hosting a custom vector "server" are clearly capable of setting up a DNS record...
     platform: linux/arm64
     image: ghcr.io/kercre123/wire-pod:main
     restart: unless-stopped

--- a/compose.yaml
+++ b/compose.yaml
@@ -12,7 +12,7 @@ services:
       - 80:80
       - 8084:8084
     volumes:
-      # get rid of caching the chipper dir, this should be baked into the image IMHO, and is a problem b/c rebuilding image and copying changes into /chipper is masked by an already UP'd volume mount...
+      # TODO this is a problem to use a volume for /chipper in terms of updates, can we split out just the part that has the database we need to preserve and not cache the codebase? otherwise once created it will never update if image contents change...  admittedly the compose file here does not appear designed for the use case of updating at all (neither via a volume nor via the image...?)
       # - wire-pod-data:/chipper/
       - wire-pod-model:/vosk/
 volumes:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,7 +1,7 @@
-version: '3.8'
 services:
   wire-pod:
     hostname: escapepod
+    build: .
     image: ghcr.io/kercre123/wire-pod:main
     restart: unless-stopped
     ports:

--- a/compose.yaml
+++ b/compose.yaml
@@ -4,7 +4,11 @@ services:
     build: .
     network_mode: host # b/c mDNS escapepod.local broadcast... why use mDNS? people hosting a custom vector "server" are clearly capable of setting up a DNS record...
     platform: linux/arm64
-    image: ghcr.io/kercre123/wire-pod:main
+    # image: ghcr.io/kercre123/wire-pod:main
+    image: ghcr_io_kercre123__wire-pod_last_known_working_main_23months_ago
+    # docker image tag 9756be63cb9b ghcr_io_kercre123__wire-pod_last_known_working_main_23months_ago
+    #    I had pulled a newer main image and it didn't work (git repo error)... so I still had old image and tagged it and switched back to it
+    #    FYI tried updating to see if I can configure openai endpoint for completions... cuz that setting isn't in UX currently... for knowledge graph
     restart: unless-stopped
     ports:
       - 443:443

--- a/dockerfile
+++ b/dockerfile
@@ -34,6 +34,6 @@ RUN cd /vector-cloud && go mod download
 COPY . .
 RUN dos2unix /chipper/start.sh
 # TODO do we really need dos2unix? can't we use editorconfig or something else to enforce line endings? and/or force git checkout to have LF endings always? SAME with setup.sh above too
-
+RUN ["/bin/sh", "-c", "DO_GO_BUILD=true ./chipper/start.sh"]
 # TODO go build chipper&vector-cloud - bake into this image (perhaps modify start.sh to do this (sep build param) or just inline go build here)
 CMD ["/bin/sh", "-c", "./chipper/start.sh"]

--- a/dockerfile
+++ b/dockerfile
@@ -20,11 +20,14 @@ RUN ["/bin/sh", "-c", "STT=vosk IMAGE_BUILD=true SETUP_STAGE=getSTT ./setup.sh"]
 # *** END PACKAGE INSTALLS ***
 
 # *** go download deps ***
+#
+# PRN build + cache deps:  # RUN --mount=type=cache,target=/root/go/pkg/mod cd /chipper && go mod download
+#
 COPY ./vector-cloud/go.sum ./vector-cloud/go.mod /vector-cloud/
 RUN cd /chipper && go mod download
 # vector-cloud deps are normally downloaded after initial web server Submit Settings page:
-  RUN cd /vector-cloud && go mod download
-  # PRN IIUC vector-cloud has some vosk model download/setup, can I add it to this image build too?
+RUN cd /vector-cloud && go mod download
+# PRN IIUC vector-cloud has some vosk model download/setup, can I add it to this image build too?
 # *** END go download deps ***
 
 # PRN copy specific files only: # COPY chipper images vector-cloud /

--- a/dockerfile
+++ b/dockerfile
@@ -1,14 +1,17 @@
 FROM ubuntu
 
 
+# *** PACKAGE INSTALLS ***
 # install packages before copying in source so we don't do this on every source change
 RUN apt-get update && \
   apt-get install -y dos2unix avahi-daemon avahi-autoipd
-
+#
 # setup.sh is standalone (IIUC upon cursory inspection) at least for debian/aarch64 + vosk purposes
+# setup.sh is more or less further `apt install...` + some file setup (i.e. chipper/source.sh)... thus run this as early as possible as it is not likely to change (as much) as the source code
 COPY setup.sh /setup.sh
 RUN dos2unix /setup.sh && mkdir /chipper
 RUN ["/bin/sh", "-c", "STT=vosk ./setup.sh"]
+# *** END PACKAGE INSTALLS ***
 
 # TODO figure out if anything gets clobbered that was created by setup.sh (i.e. ./chipper/source.sh which is created by setup.sh)
 COPY . .

--- a/dockerfile
+++ b/dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && \
 # setup.sh is standalone (IIUC upon cursory inspection) at least for debian/aarch64 + vosk purposes
 # setup.sh is more or less further `apt install...` + some file setup (i.e. chipper/source.sh)... thus run this as early as possible as it is not likely to change (as much) as the source code
 COPY setup.sh /setup.sh
+# PRN part of what setup.sh does is to install golang and other deps... why not extract those deps here for the Dockerfile and not use setup.sh inside the container build? AND why not find a golang base image to build on top of instead of installing it here?
 RUN dos2unix /setup.sh && mkdir /chipper && mkdir /vector-cloud
 RUN ["/bin/sh", "-c", "STT=vosk ./setup.sh"]
 # *** END PACKAGE INSTALLS ***

--- a/dockerfile
+++ b/dockerfile
@@ -20,9 +20,9 @@ RUN ["/bin/sh", "-c", "STT=vosk IMAGE_BUILD=true SETUP_STAGE=getSTT ./setup.sh"]
 # *** END PACKAGE INSTALLS ***
 
 # TODO figure out if anything gets clobbered that was created by setup.sh (i.e. ./chipper/source.sh which is created by setup.sh)
-# COPY . .
+COPY . .
 
 # TODO do we really need dos2unix? can't we use editorconfig or something else to enforce line endings? and/or force git checkout to have LF endings always? SAME with setup.sh above too
-# RUN dos2unix /chipper/start.sh
+RUN dos2unix /chipper/start.sh
 
-#CMD ["/bin/sh", "-c", "./chipper/start.sh"]
+CMD ["/bin/sh", "-c", "./chipper/start.sh"]

--- a/dockerfile
+++ b/dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu
 
 COPY . .
 
+# TODO move some or all package installs before copying code
 RUN chmod +x /setup.sh && apt-get update && apt-get install -y dos2unix && dos2unix /setup.sh && apt-get install -y avahi-daemon avahi-autoipd
 
 RUN ["/bin/sh", "-c", "STT=vosk ./setup.sh"]

--- a/dockerfile
+++ b/dockerfile
@@ -32,5 +32,5 @@ COPY . .
 RUN dos2unix /chipper/start.sh
 # TODO do we really need dos2unix? can't we use editorconfig or something else to enforce line endings? and/or force git checkout to have LF endings always? SAME with setup.sh above too
 
-
+# TODO go build chipper&vector-cloud - bake into this image (perhaps modify start.sh to do this (sep build param) or just inline go build here)
 CMD ["/bin/sh", "-c", "./chipper/start.sh"]

--- a/dockerfile
+++ b/dockerfile
@@ -12,13 +12,17 @@ COPY setup.sh /setup.sh
 # PRN part of what setup.sh does is to install golang and other deps... why not extract those deps here for the Dockerfile and not use setup.sh inside the container build? AND why not find a golang base image to build on top of instead of installing it here?
 RUN dos2unix /setup.sh && mkdir /chipper && mkdir /vector-cloud
 RUN ["/bin/sh", "-c", "STT=vosk IMAGE_BUILD=true SETUP_STAGE=getPackages ./setup.sh"]
+
+# so we can install go deps (IIUC for vosk install in setup.sh/getSTT)
+COPY ./chipper/go.sum ./chipper/go.mod /chipper/
+# PRN caching of downloaded modules?
 RUN ["/bin/sh", "-c", "STT=vosk IMAGE_BUILD=true SETUP_STAGE=getSTT ./setup.sh"]
 # *** END PACKAGE INSTALLS ***
 
 # TODO figure out if anything gets clobbered that was created by setup.sh (i.e. ./chipper/source.sh which is created by setup.sh)
-COPY . .
+# COPY . .
 
 # TODO do we really need dos2unix? can't we use editorconfig or something else to enforce line endings? and/or force git checkout to have LF endings always? SAME with setup.sh above too
-RUN dos2unix /chipper/start.sh
+# RUN dos2unix /chipper/start.sh
 
-CMD ["/bin/sh", "-c", "./chipper/start.sh"]
+#CMD ["/bin/sh", "-c", "./chipper/start.sh"]

--- a/dockerfile
+++ b/dockerfile
@@ -11,7 +11,8 @@ RUN apt-get update && \
 COPY setup.sh /setup.sh
 # PRN part of what setup.sh does is to install golang and other deps... why not extract those deps here for the Dockerfile and not use setup.sh inside the container build? AND why not find a golang base image to build on top of instead of installing it here?
 RUN dos2unix /setup.sh && mkdir /chipper && mkdir /vector-cloud
-RUN ["/bin/sh", "-c", "STT=vosk IMAGE_BUILD=true ./setup.sh"]
+RUN ["/bin/sh", "-c", "STT=vosk IMAGE_BUILD=true BUILD_STAGE=getPackages ./setup.sh"]
+RUN ["/bin/sh", "-c", "STT=vosk IMAGE_BUILD=true BUILD_STAGE=getSTT ./setup.sh"]
 # *** END PACKAGE INSTALLS ***
 
 # TODO figure out if anything gets clobbered that was created by setup.sh (i.e. ./chipper/source.sh which is created by setup.sh)

--- a/dockerfile
+++ b/dockerfile
@@ -11,8 +11,8 @@ RUN apt-get update && \
 COPY setup.sh /setup.sh
 # PRN part of what setup.sh does is to install golang and other deps... why not extract those deps here for the Dockerfile and not use setup.sh inside the container build? AND why not find a golang base image to build on top of instead of installing it here?
 RUN dos2unix /setup.sh && mkdir /chipper && mkdir /vector-cloud
-RUN ["/bin/sh", "-c", "STT=vosk IMAGE_BUILD=true BUILD_STAGE=getPackages ./setup.sh"]
-RUN ["/bin/sh", "-c", "STT=vosk IMAGE_BUILD=true BUILD_STAGE=getSTT ./setup.sh"]
+RUN ["/bin/sh", "-c", "STT=vosk IMAGE_BUILD=true SETUP_STAGE=getPackages ./setup.sh"]
+RUN ["/bin/sh", "-c", "STT=vosk IMAGE_BUILD=true SETUP_STAGE=getSTT ./setup.sh"]
 # *** END PACKAGE INSTALLS ***
 
 # TODO figure out if anything gets clobbered that was created by setup.sh (i.e. ./chipper/source.sh which is created by setup.sh)

--- a/dockerfile
+++ b/dockerfile
@@ -21,8 +21,9 @@ RUN ["/bin/sh", "-c", "STT=vosk IMAGE_BUILD=true SETUP_STAGE=getSTT ./setup.sh"]
 
 # TODO figure out if anything gets clobbered that was created by setup.sh (i.e. ./chipper/source.sh which is created by setup.sh)
 COPY . .
-
-# TODO do we really need dos2unix? can't we use editorconfig or something else to enforce line endings? and/or force git checkout to have LF endings always? SAME with setup.sh above too
 RUN dos2unix /chipper/start.sh
+# TODO do we really need dos2unix? can't we use editorconfig or something else to enforce line endings? and/or force git checkout to have LF endings always? SAME with setup.sh above too
 
+# TODO step 1 - add go get/install for runtime modules into a last layer
+#   setup 2 - ascertain if I can move go get/install earlier in the Dockerfile (if that has any benefit)
 CMD ["/bin/sh", "-c", "./chipper/start.sh"]

--- a/dockerfile
+++ b/dockerfile
@@ -19,19 +19,14 @@ COPY ./chipper/go.sum ./chipper/go.mod /chipper/
 RUN ["/bin/sh", "-c", "STT=vosk IMAGE_BUILD=true SETUP_STAGE=getSTT ./setup.sh"]
 # *** END PACKAGE INSTALLS ***
 
-# TODO figure out if anything gets clobbered that was created by setup.sh (i.e. ./chipper/source.sh which is created by setup.sh)
-# TODO can we only copy:
-#  COPY chipper images /
-#    IIAC docker doesn't need update.sh (b/c instead just rebuild image, IIAC)
-#    IIUC vector-cloud isn't part of the server (gh issue mentions possibly removing it - is it part of custom ep firmeware that runs on vector?)
+# PRN copy specific files only: # COPY chipper images vector-cloud /
 COPY . .
 RUN dos2unix /chipper/start.sh
 # TODO do we really need dos2unix? can't we use editorconfig or something else to enforce line endings? and/or force git checkout to have LF endings always? SAME with setup.sh above too
 
 # TODO now look into moving this higher in build (next)
 RUN cd /chipper && go mod download
-# TODO web server initial setup page => after submit settings => downloads vosk model smth? then more go modules are downloaded
-#   Are these the vector-cloud deps?
+# vector-cloud is setup/installed after initial web server Submit Settings page
 RUN cd /vector-cloud && go mod download
 
 CMD ["/bin/sh", "-c", "./chipper/start.sh"]

--- a/dockerfile
+++ b/dockerfile
@@ -15,7 +15,7 @@ RUN ["/bin/sh", "-c", "STT=vosk IMAGE_BUILD=true SETUP_STAGE=getPackages ./setup
 
 # so we can install go deps (IIUC for vosk install in setup.sh/getSTT)
 COPY ./chipper/go.sum ./chipper/go.mod /chipper/
-# PRN caching of downloaded modules?
+# FYI setup.sh generates /chipper/source.sh: contains env vars for STT_SERVICE & DEBUG_LOGGING for vosk setup.sh:
 RUN ["/bin/sh", "-c", "STT=vosk IMAGE_BUILD=true SETUP_STAGE=getSTT ./setup.sh"]
 # *** END PACKAGE INSTALLS ***
 

--- a/dockerfile
+++ b/dockerfile
@@ -15,7 +15,7 @@ RUN ["/bin/sh", "-c", "STT=vosk IMAGE_BUILD=true SETUP_STAGE=getPackages ./setup
 
 # so we can install go deps (IIUC for vosk install in setup.sh/getSTT)
 COPY ./chipper/go.sum ./chipper/go.mod /chipper/
-# FYI setup.sh generates /chipper/source.sh: contains env vars for STT_SERVICE & DEBUG_LOGGING for vosk setup.sh:
+# FYI setup.sh generates /chipper/source.sh which sets env vars only
 RUN ["/bin/sh", "-c", "STT=vosk IMAGE_BUILD=true SETUP_STAGE=getSTT ./setup.sh"]
 # *** END PACKAGE INSTALLS ***
 

--- a/dockerfile
+++ b/dockerfile
@@ -28,6 +28,7 @@ RUN cd /chipper && go mod download
 # vector-cloud deps are normally downloaded after initial web server Submit Settings page:
 RUN cd /vector-cloud && go mod download
 # PRN IIUC vector-cloud has some vosk model download/setup, can I add it to this image build too?
+#     Downloading https://github.com/kercre123/vosk-models/raw/main/vosk-model-small-en-us-0.15.zip to /tmp/vosk-model-small-en-us-0.15.zip
 # *** END go download deps ***
 
 # PRN copy specific files only: # COPY chipper images vector-cloud /

--- a/dockerfile
+++ b/dockerfile
@@ -5,11 +5,13 @@ FROM ubuntu
 RUN apt-get update && \
   apt-get install -y dos2unix avahi-daemon avahi-autoipd
 
-COPY . .
-
-RUN apt-get update && dos2unix /setup.sh
-
+# setup.sh is standalone (IIUC upon cursory inspection) at least for debian/aarch64 + vosk purposes
+COPY setup.sh /setup.sh
+RUN dos2unix /setup.sh
 RUN ["/bin/sh", "-c", "STT=vosk ./setup.sh"]
+
+# TODO figure out if anything gets clobbered that was created by setup.sh (i.e. ./chipper/source.sh which is created by setup.sh)
+COPY . .
 
 RUN dos2unix /chipper/start.sh
 

--- a/dockerfile
+++ b/dockerfile
@@ -7,10 +7,10 @@ RUN apt-get update && \
 
 COPY . .
 
-RUN chmod +x /setup.sh && apt-get update && dos2unix /setup.sh
+RUN apt-get update && dos2unix /setup.sh
 
 RUN ["/bin/sh", "-c", "STT=vosk ./setup.sh"]
 
-RUN chmod +x /chipper/start.sh && dos2unix /chipper/start.sh
+RUN dos2unix /chipper/start.sh
 
 CMD ["/bin/sh", "-c", "./chipper/start.sh"]

--- a/dockerfile
+++ b/dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
 
 # setup.sh is standalone (IIUC upon cursory inspection) at least for debian/aarch64 + vosk purposes
 COPY setup.sh /setup.sh
-RUN dos2unix /setup.sh
+RUN dos2unix /setup.sh && mkdir /chipper
 RUN ["/bin/sh", "-c", "STT=vosk ./setup.sh"]
 
 # TODO figure out if anything gets clobbered that was created by setup.sh (i.e. ./chipper/source.sh which is created by setup.sh)

--- a/dockerfile
+++ b/dockerfile
@@ -16,6 +16,7 @@ RUN ["/bin/sh", "-c", "STT=vosk ./setup.sh"]
 # TODO figure out if anything gets clobbered that was created by setup.sh (i.e. ./chipper/source.sh which is created by setup.sh)
 COPY . .
 
+# TODO do we really need dos2unix? can't we use editorconfig or something else to enforce line endings? and/or force git checkout to have LF endings always? SAME with setup.sh above too
 RUN dos2unix /chipper/start.sh
 
 CMD ["/bin/sh", "-c", "./chipper/start.sh"]

--- a/dockerfile
+++ b/dockerfile
@@ -31,7 +31,8 @@ RUN dos2unix /chipper/start.sh
 # TODO step 1 - add go get/install for runtime modules into a last layer
 #   setup 2 - ascertain if I can move go get/install earlier in the Dockerfile (if that has any benefit)
 # go build to pull further go deps:
-RUN ["/bin/sh", "-c", "GO_COMMAND=build ./chipper/start.sh"]
+# RUN ["/bin/sh", "-c", "GO_COMMAND=build ./chipper/start.sh"]
+RUN cd /chipper && go mod download
 #
 # runtime:
 CMD ["/bin/sh", "-c", "GO_COMMAND=run ./chipper/start.sh"]

--- a/dockerfile
+++ b/dockerfile
@@ -31,5 +31,7 @@ RUN dos2unix /chipper/start.sh
 # TODO now look into moving this higher in build (next)
 RUN cd /chipper && go mod download
 # TODO web server initial setup page => after submit settings => downloads vosk model smth? then more go modules are downloaded
+#   Are these the vector-cloud deps?
+RUN cd /vector-cloud && go mod download
 
 CMD ["/bin/sh", "-c", "./chipper/start.sh"]

--- a/dockerfile
+++ b/dockerfile
@@ -1,10 +1,13 @@
 FROM ubuntu
 
 
+# install packages before copying in source so we don't do this on every source change
+RUN apt-get update && \
+  apt-get install -y dos2unix avahi-daemon avahi-autoipd
+
 COPY . .
 
-# TODO move some or all package installs before copying code
-RUN chmod +x /setup.sh && apt-get update && apt-get install -y dos2unix && dos2unix /setup.sh && apt-get install -y avahi-daemon avahi-autoipd
+RUN chmod +x /setup.sh && apt-get update && dos2unix /setup.sh
 
 RUN ["/bin/sh", "-c", "STT=vosk ./setup.sh"]
 

--- a/dockerfile
+++ b/dockerfile
@@ -20,6 +20,10 @@ RUN ["/bin/sh", "-c", "STT=vosk IMAGE_BUILD=true SETUP_STAGE=getSTT ./setup.sh"]
 # *** END PACKAGE INSTALLS ***
 
 # TODO figure out if anything gets clobbered that was created by setup.sh (i.e. ./chipper/source.sh which is created by setup.sh)
+# TODO can we only copy:
+#  COPY chipper images /
+#    IIAC docker doesn't need update.sh (b/c instead just rebuild image, IIAC)
+#    IIUC vector-cloud isn't part of the server (gh issue mentions possibly removing it - is it part of custom ep firmeware that runs on vector?)
 COPY . .
 RUN dos2unix /chipper/start.sh
 # TODO do we really need dos2unix? can't we use editorconfig or something else to enforce line endings? and/or force git checkout to have LF endings always? SAME with setup.sh above too

--- a/dockerfile
+++ b/dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && \
 # setup.sh is standalone (IIUC upon cursory inspection) at least for debian/aarch64 + vosk purposes
 # setup.sh is more or less further `apt install...` + some file setup (i.e. chipper/source.sh)... thus run this as early as possible as it is not likely to change (as much) as the source code
 COPY setup.sh /setup.sh
-RUN dos2unix /setup.sh && mkdir /chipper
+RUN dos2unix /setup.sh && mkdir /chipper && mkdir /vector-cloud
 RUN ["/bin/sh", "-c", "STT=vosk ./setup.sh"]
 # *** END PACKAGE INSTALLS ***
 

--- a/dockerfile
+++ b/dockerfile
@@ -34,6 +34,11 @@ RUN cd /vector-cloud && go mod download
 COPY . .
 RUN dos2unix /chipper/start.sh
 # TODO do we really need dos2unix? can't we use editorconfig or something else to enforce line endings? and/or force git checkout to have LF endings always? SAME with setup.sh above too
+#
+# build chipper during image build:
+#   reuse start.sh so we keep logic for changing env vars (i.e. for whipser instead of vosk)
 RUN ["/bin/sh", "-c", "DO_GO_BUILD=true ./chipper/start.sh"]
-# TODO go build chipper&vector-cloud - bake into this image (perhaps modify start.sh to do this (sep build param) or just inline go build here)
+# PRN build vector-cloud during image build too?
+# PRN use multi-stage build - with builder image (w/ cached modules) separate of runtime image (final executables only)?
+
 CMD ["/bin/sh", "-c", "./chipper/start.sh"]

--- a/dockerfile
+++ b/dockerfile
@@ -19,14 +19,18 @@ COPY ./chipper/go.sum ./chipper/go.mod /chipper/
 RUN ["/bin/sh", "-c", "STT=vosk IMAGE_BUILD=true SETUP_STAGE=getSTT ./setup.sh"]
 # *** END PACKAGE INSTALLS ***
 
+# *** go download deps ***
+COPY ./vector-cloud/go.sum ./vector-cloud/go.mod /vector-cloud/
+RUN cd /chipper && go mod download
+# vector-cloud deps are normally downloaded after initial web server Submit Settings page:
+  RUN cd /vector-cloud && go mod download
+  # PRN IIUC vector-cloud has some vosk model download/setup, can I add it to this image build too?
+# *** END go download deps ***
+
 # PRN copy specific files only: # COPY chipper images vector-cloud /
 COPY . .
 RUN dos2unix /chipper/start.sh
 # TODO do we really need dos2unix? can't we use editorconfig or something else to enforce line endings? and/or force git checkout to have LF endings always? SAME with setup.sh above too
 
-# TODO now look into moving this higher in build (next)
-RUN cd /chipper && go mod download
-# vector-cloud is setup/installed after initial web server Submit Settings page
-RUN cd /vector-cloud && go mod download
 
 CMD ["/bin/sh", "-c", "./chipper/start.sh"]

--- a/dockerfile
+++ b/dockerfile
@@ -7,11 +7,11 @@ RUN apt-get update && \
   apt-get install -y dos2unix avahi-daemon avahi-autoipd
 #
 # setup.sh is standalone (IIUC upon cursory inspection) at least for debian/aarch64 + vosk purposes
-# setup.sh is more or less further `apt install...` + some file setup (i.e. chipper/source.sh)... thus run this as early as possible as it is not likely to change (as much) as the source code
+# setup.sh is more or less further `apt install...` + golang install + vosk install + gen chipper/source.sh... thus run this as early as possible as it is not likely to change (as much) as the source code
 COPY setup.sh /setup.sh
 # PRN part of what setup.sh does is to install golang and other deps... why not extract those deps here for the Dockerfile and not use setup.sh inside the container build? AND why not find a golang base image to build on top of instead of installing it here?
 RUN dos2unix /setup.sh && mkdir /chipper && mkdir /vector-cloud
-RUN ["/bin/sh", "-c", "STT=vosk ./setup.sh"]
+RUN ["/bin/sh", "-c", "STT=vosk IMAGE_BUILD=true ./setup.sh"]
 # *** END PACKAGE INSTALLS ***
 
 # TODO figure out if anything gets clobbered that was created by setup.sh (i.e. ./chipper/source.sh which is created by setup.sh)

--- a/dockerfile
+++ b/dockerfile
@@ -30,4 +30,8 @@ RUN dos2unix /chipper/start.sh
 
 # TODO step 1 - add go get/install for runtime modules into a last layer
 #   setup 2 - ascertain if I can move go get/install earlier in the Dockerfile (if that has any benefit)
-CMD ["/bin/sh", "-c", "./chipper/start.sh"]
+# go build to pull further go deps:
+RUN ["/bin/sh", "-c", "GO_COMMAND=build ./chipper/start.sh"]
+#
+# runtime:
+CMD ["/bin/sh", "-c", "GO_COMMAND=run ./chipper/start.sh"]

--- a/dockerfile
+++ b/dockerfile
@@ -28,11 +28,7 @@ COPY . .
 RUN dos2unix /chipper/start.sh
 # TODO do we really need dos2unix? can't we use editorconfig or something else to enforce line endings? and/or force git checkout to have LF endings always? SAME with setup.sh above too
 
-# TODO step 1 - add go get/install for runtime modules into a last layer
-#   setup 2 - ascertain if I can move go get/install earlier in the Dockerfile (if that has any benefit)
-# go build to pull further go deps:
-# RUN ["/bin/sh", "-c", "GO_COMMAND=build ./chipper/start.sh"]
+# TODO now look into moving this higher in build (next)
 RUN cd /chipper && go mod download
-#
-# runtime:
-CMD ["/bin/sh", "-c", "GO_COMMAND=run ./chipper/start.sh"]
+
+CMD ["/bin/sh", "-c", "./chipper/start.sh"]

--- a/dockerfile
+++ b/dockerfile
@@ -30,5 +30,6 @@ RUN dos2unix /chipper/start.sh
 
 # TODO now look into moving this higher in build (next)
 RUN cd /chipper && go mod download
+# TODO web server initial setup page => after submit settings => downloads vosk model smth? then more go modules are downloaded
 
 CMD ["/bin/sh", "-c", "./chipper/start.sh"]

--- a/setup.sh
+++ b/setup.sh
@@ -651,11 +651,14 @@ if [[ $1 == "-f" ]] && [[ $2 == "scp" ]]; then
     exit 0
 fi
 
-# TODO container detect and break up stages so we can avoid re-run everything?
-
-# check IMAGE_BUILD env var is set to determine if building image
 if [[ -n "${IMAGE_BUILD}" ]]; then
     echo "Detected container build env..."
+    # break up stages so we can avoid re-run everything?
+    echo
+    getPackages
+    getSTT
+    echo
+    echo "wire-pod is ready to run! You are ready to move to the next step and run sudo ./chipper/start.sh" 
     exit 1
 fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -651,6 +651,15 @@ if [[ $1 == "-f" ]] && [[ $2 == "scp" ]]; then
     exit 0
 fi
 
+# TODO container detect and break up stages so we can avoid re-run everything?
+
+# check IMAGE_BUILD env var is set to determine if building image
+if [[ -n "${IMAGE_BUILD}" ]]; then
+    echo "Detected container build env..."
+    exit 1
+fi
+
+
 # echo "What would you like to do?"
 # echo "1: Full Setup (recommended) (builds chipper, gets STT stuff, generates certs, creates source.sh file, and creates server_config.json for your bot"
 # echo "2: Just build vic-cloud"

--- a/setup.sh
+++ b/setup.sh
@@ -653,19 +653,17 @@ fi
 
 if [[ -n "${IMAGE_BUILD}" ]]; then
     echo "Detected container build env..."
-    # break up stages so we can avoid re-run everything?
-    # if env var BUILD_STAGE == getPackages
-    if [[ "${BUILD_STAGE}" == "getPackages" ]]; then
+    if [[ "${SETUP_STAGE}" == "getPackages" ]]; then
         getPackages
         exit 0
     fi
     # TODO add stage to install golang too and move it to first stage? or use base image with golang already installed
-    if [[ "${BUILD_STAGE}" == "getSTT" ]]; then
+    if [[ "${SETUP_STAGE}" == "getSTT" ]]; then
         getSTT
-        echo "wire-pod is ready to run! You are ready to move to the next step and run sudo ./chipper/start.sh" 
+        echo "wire-pod is ready to run! You are ready to move to the next step and run sudo ./chipper/start.sh"
         exit 0
     fi
-    echo "Please provide a valid BUILD_STAGE env var, the current value is '${BUILD_STAGE}' is not recognized"
+    echo "Please provide a valid SETUP_STAGE env var, the current value is '${SETUP_STAGE}' is not recognized"
     exit 1
 fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -26,13 +26,13 @@ if [[ ${UNAME} == *"Darwin"* ]]; then
         echo '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"'
         exit 1
     fi
-    elif [[ -f /usr/bin/apt ]]; then
+elif [[ -f /usr/bin/apt ]]; then
     TARGET="debian"
     echo "Debian-based Linux detected."
-    elif [[ -f /usr/bin/pacman ]]; then
+elif [[ -f /usr/bin/pacman ]]; then
     TARGET="arch"
     echo "Arch Linux detected."
-    elif [[ -f /usr/bin/dnf ]]; then
+elif [[ -f /usr/bin/dnf ]]; then
     TARGET="fedora"
     echo "Fedora/openSUSE detected."
 else
@@ -47,10 +47,10 @@ fi
 if [[ "${UNAME}" == *"x86_64"* ]]; then
     ARCH="x86_64"
     echo "amd64 architecture confirmed."
-    elif [[ "${UNAME}" == *"aarch64"* ]] || [[ "${UNAME}" == *"arm64"* ]]; then
+elif [[ "${UNAME}" == *"aarch64"* ]] || [[ "${UNAME}" == *"arm64"* ]]; then
     ARCH="aarch64"
     echo "aarch64 architecture confirmed."
-    elif [[ "${UNAME}" == *"armv7l"* ]]; then
+elif [[ "${UNAME}" == *"armv7l"* ]]; then
     ARCH="armv7l"
     echo "armv7l (32-bit) WARN: The Coqui and VOSK bindings are broken for this platform at the moment, so please choose Picovoice when the script asks. wire-pod is designed for 64-bit systems."
     STT=""
@@ -91,13 +91,13 @@ function getPackages() {
     if [[ ${TARGET} == "debian" ]]; then
         apt update -y
         apt install -y wget openssl net-tools libsox-dev libopus-dev make iproute2 xz-utils libopusfile-dev pkg-config gcc curl g++ unzip avahi-daemon git libasound2-dev libsodium-dev
-        elif [[ ${TARGET} == "arch" ]]; then
+    elif [[ ${TARGET} == "arch" ]]; then
         pacman -Sy --noconfirm
         sudo pacman -S --noconfirm wget openssl net-tools sox opus make iproute2 opusfile curl unzip avahi git libsodium go pkg-config
-        elif [[ ${TARGET} == "fedora" ]]; then
+    elif [[ ${TARGET} == "fedora" ]]; then
         dnf update
         dnf install -y wget openssl net-tools sox opus make opusfile curl unzip avahi git libsodium-devel
-        elif [[ ${TARGET} == "darwin" ]]; then
+    elif [[ ${TARGET} == "darwin" ]]; then
         sudo -u $SUDO_USER brew update
         sudo -u $SUDO_USER brew install wget pkg-config opus opusfile
     fi
@@ -111,10 +111,10 @@ function getPackages() {
             if [[ ${ARCH} == "x86_64" ]]; then
                 wget -q --show-progress --no-check-certificate https://go.dev/dl/go1.19.4.linux-amd64.tar.gz
                 rm -rf /usr/local/go && tar -C /usr/local -xzf go1.19.4.linux-amd64.tar.gz
-                elif [[ ${ARCH} == "aarch64" ]]; then
+            elif [[ ${ARCH} == "aarch64" ]]; then
                 wget -q --show-progress --no-check-certificate https://go.dev/dl/go1.19.4.linux-arm64.tar.gz
                 rm -rf /usr/local/go && tar -C /usr/local -xzf go1.19.4.linux-arm64.tar.gz
-                elif [[ ${ARCH} == "armv7l" ]]; then
+            elif [[ ${ARCH} == "armv7l" ]]; then
                 wget -q --show-progress --no-check-certificate https://go.dev/dl/go1.19.4.linux-armv6l.tar.gz
                 rm -rf /usr/local/go && tar -C /usr/local -xzf go1.19.4.linux-armv6l.tar.gz
             fi
@@ -146,18 +146,18 @@ function getSTT() {
         read -p "Enter a number (3): " sttServiceNum
         if [[ ! -n ${sttServiceNum} ]]; then
             sttService="vosk"
-            elif [[ ${sttServiceNum} == "1" ]]; then
+        elif [[ ${sttServiceNum} == "1" ]]; then
             if [[ ${TARGET} == "darwin" ]]; then
                 echo "Coqui is not supported for macOS. Please select another option."
                 sttServicePrompt
             else
                 sttService="coqui"
             fi
-            elif [[ ${sttServiceNum} == "2" ]]; then
+        elif [[ ${sttServiceNum} == "2" ]]; then
             sttService="leopard"
-            elif [[ ${sttServiceNum} == "3" ]]; then
+        elif [[ ${sttServiceNum} == "3" ]]; then
             sttService="vosk"
-            elif [[ ${sttServiceNum} == "4" ]]; then
+        elif [[ ${sttServiceNum} == "4" ]]; then
             sttService="whisper"
         else
             echo
@@ -187,7 +187,7 @@ function getSTT() {
         echo "export STT_SERVICE=leopard" >> ./chipper/source.sh
         echo "export PICOVOICE_APIKEY=${picoKey}" >> ./chipper/source.sh
         echo "export PICOVOICE_APIKEY=${picoKey}" > ./chipper/pico.key
-        elif [[ ${sttService} == "vosk" ]]; then
+    elif [[ ${sttService} == "vosk" ]]; then
         echo "export STT_SERVICE=vosk" >> ./chipper/source.sh
         origDir="$(pwd)"
         if [[ ! -f ./vosk/completed ]]; then
@@ -199,11 +199,11 @@ function getSTT() {
             if [[ ${TARGET} == "darwin" ]]; then
                 VOSK_VER="0.3.42"
                 VOSK_DIR="vosk-osx-${VOSK_VER}"
-                elif [[ ${ARCH} == "x86_64" ]]; then
+            elif [[ ${ARCH} == "x86_64" ]]; then
                 VOSK_DIR="vosk-linux-x86_64-${VOSK_VER}"
-                elif [[ ${ARCH} == "aarch64" ]]; then
+            elif [[ ${ARCH} == "aarch64" ]]; then
                 VOSK_DIR="vosk-linux-aarch64-${VOSK_VER}"
-                elif [[ ${ARCH} == "armv7l" ]]; then
+            elif [[ ${ARCH} == "armv7l" ]]; then
                 VOSK_DIR="vosk-linux-armv7l-${VOSK_VER}"
             fi
             VOSK_ARCHIVE="$VOSK_DIR.zip"
@@ -222,7 +222,7 @@ function getSTT() {
             /usr/local/go/bin/go install github.com/kercre123/vosk-api/go
             cd ${origDir}
         fi
-        elif [[ ${sttService} == "whisper" ]]; then
+    elif [[ ${sttService} == "whisper" ]]; then
         echo "export STT_SERVICE=whisper.cpp" >> ./chipper/source.sh
         origDir="$(pwd)"
         echo "Getting Whisper assets"
@@ -276,11 +276,11 @@ function getSTT() {
                 fi
                 tar -xf native_client.tflite.Linux.tar.xz
                 rm -f ./native_client.tflite.Linux.tar.xz
-                elif [[ ${ARCH} == "aarch64" ]]; then
+            elif [[ ${ARCH} == "aarch64" ]]; then
                 wget -q --show-progress --no-check-certificate https://github.com/coqui-ai/STT/releases/download/v1.3.0/native_client.tflite.linux.aarch64.tar.xz
                 tar -xf native_client.tflite.linux.aarch64.tar.xz
                 rm -f ./native_client.tflite.linux.aarch64.tar.xz
-                elif [[ ${ARCH} == "armv7l" ]]; then
+            elif [[ ${ARCH} == "armv7l" ]]; then
                 wget -q --show-progress --no-check-certificate https://github.com/coqui-ai/STT/releases/download/v1.3.0/native_client.tflite.linux.armv7.tar.xz
                 tar -xf native_client.tflite.linux.armv7.tar.xz
                 rm -f ./native_client.tflite.linux.armv7.tar.xz
@@ -304,9 +304,9 @@ function getSTT() {
                 read -p "Enter a number (1): " sttModelNum
                 if [[ ! -n ${sttModelNum} ]]; then
                     sttModel="large_vocabulary"
-                    elif [[ ${sttModelNum} == "1" ]]; then
+                elif [[ ${sttModelNum} == "1" ]]; then
                     sttModel="large_vocabulary"
-                    elif [[ ${sttModelNum} == "2" ]]; then
+                elif [[ ${sttModelNum} == "2" ]]; then
                     sttModel="huge_vocabulary"
                 else
                     echo
@@ -323,7 +323,7 @@ function getSTT() {
                 wget -O model.tflite -q --show-progress --no-check-certificate https://coqui.gateway.scarf.sh/english/coqui/v1.0.0-large-vocab/model.tflite
                 echo "Getting STT scorer..."
                 wget -O model.scorer -q --show-progress --no-check-certificate https://coqui.gateway.scarf.sh/english/coqui/v1.0.0-large-vocab/large_vocabulary.scorer
-                elif [[ ${sttModel} == "huge_vocabulary" ]]; then
+            elif [[ ${sttModel} == "huge_vocabulary" ]]; then
                 echo "Getting STT model..."
                 wget -O model.tflite -q --show-progress --no-check-certificate https://coqui.gateway.scarf.sh/english/coqui/v1.0.0-huge-vocab/model.tflite
                 echo "Getting STT scorer..."
@@ -565,14 +565,14 @@ function setupSystemd() {
     if [[ ${STT_SERVICE} == "leopard" ]]; then
         echo "wire-pod.service created, building chipper with Picovoice STT service..."
         /usr/local/go/bin/go build -tags $GOTAGS cmd/leopard/main.go
-        elif [[ ${STT_SERVICE} == "vosk" ]]; then
+    elif [[ ${STT_SERVICE} == "vosk" ]]; then
         echo "wire-pod.service created, building chipper with VOSK STT service..."
         export CGO_ENABLED=1
         export CGO_CFLAGS="-I/root/.vosk/libvosk"
         export CGO_LDFLAGS="-L /root/.vosk/libvosk -lvosk -ldl -lpthread"
         export LD_LIBRARY_PATH="/root/.vosk/libvosk:$LD_LIBRARY_PATH"
         /usr/local/go/bin/go build -tags $GOTAGS cmd/vosk/main.go
-        elif [[ ${STT_SERVICE} == "whisper.cpp" ]]; then
+    elif [[ ${STT_SERVICE} == "whisper.cpp" ]]; then
         echo "wire-pod.service created, building chipper with Whisper.CPP STT service..."
         export CGO_ENABLED=1
         export C_INCLUDE_PATH="../whisper.cpp"

--- a/setup.sh
+++ b/setup.sh
@@ -654,14 +654,20 @@ fi
 if [[ -n "${IMAGE_BUILD}" ]]; then
     echo "Detected container build env..."
     # break up stages so we can avoid re-run everything?
-    echo
-    getPackages
-    getSTT
-    echo
-    echo "wire-pod is ready to run! You are ready to move to the next step and run sudo ./chipper/start.sh" 
+    # if env var BUILD_STAGE == getPackages
+    if [[ "${BUILD_STAGE}" == "getPackages" ]]; then
+        getPackages
+        exit 0
+    fi
+    # TODO add stage to install golang too and move it to first stage? or use base image with golang already installed
+    if [[ "${BUILD_STAGE}" == "getSTT" ]]; then
+        getSTT
+        echo "wire-pod is ready to run! You are ready to move to the next step and run sudo ./chipper/start.sh" 
+        exit 0
+    fi
+    echo "Please provide a valid BUILD_STAGE env var, the current value is '${BUILD_STAGE}' is not recognized"
     exit 1
 fi
-
 
 # echo "What would you like to do?"
 # echo "1: Full Setup (recommended) (builds chipper, gets STT stuff, generates certs, creates source.sh file, and creates server_config.json for your bot"


### PR DESCRIPTION
I wanted to build/run based on the `compose.yaml` file in the repo root, so I made changes to build just about everything into the image (apt installs, some of vosk, download go mods, etc) and that really helped with startup time (takes ~2 seconds now on my raspberry pi 4B). And restarts are nearly instant as well.

I'm sharing the changes if anyone else wants to copy them. And if there is an interest in merging some/all of the changes, I could help do that too.

Some of my changes seem to conflict with how the current `compose.yaml`/`Dockerfile` are being used, so a blanket merge doesn't likely make sense. 

And, there are additional changes that would be useful:
- identifying the `json` state files and getting the image to build with those in a dedicated directory that could be setup as a docker volume to be able to recreate a container based on an updated image and not lose the server state. Right now, IIUC, state and chipper code overlap and so the `json` files need to be moved elsewhere at least as far as the container env is concerned. It appears that we might be able to set `Packaged` true to get them to be stored in a `~/.config` or similar dir?
- setup a multi-stage build w/ a builder that compiles a static linked binary and then that is copied to a "runtime" stage that is a lightweight container w/ just the compiled binar(ies). 
- refactor to use a pre-canned `golang` image as a base to avoid needing to install go in `setup.sh`
