### PR TITLE
use Radiobuttons in Controls (beta)

### DIFF
--- a/chipper/webroot/css/style.css
+++ b/chipper/webroot/css/style.css
@@ -1,11 +1,10 @@
 @import url("wing.css");
 
 @font-face{ 
-  font-family: 'IBMVGA'; 
+  font-family: 'IBMVGA';
   src: url('PxPlus_IBM_VGA_8x16.ttf') format('truetype');
   /* VileR's old school font pack - int10h.org */
 }
-
 
 @font-face{ 
   font-family: 'H1Weird';

--- a/chipper/webroot/css/style.css
+++ b/chipper/webroot/css/style.css
@@ -1,10 +1,11 @@
 @import url("wing.css");
 
 @font-face{ 
-  font-family: 'IBMVGA';
+  font-family: 'IBMVGA'; 
   src: url('PxPlus_IBM_VGA_8x16.ttf') format('truetype');
   /* VileR's old school font pack - int10h.org */
 }
+
 
 @font-face{ 
   font-family: 'H1Weird';
@@ -79,6 +80,10 @@ input[type="text"], input[type="file"], select {
   font-size: 1.0em;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
   text-align: center;
+}
+
+input[type='text']:disabled {
+  cursor: not-allowed;
 }
 
 .small-hr {
@@ -231,6 +236,15 @@ input[type='radio']:checked:after {
   background-color: var(--fg-color);
   content: '';
   display: inline-block;
+}
+
+input[type='radio']:disabled {
+  cursor: not-allowed;
+}
+
+input[type='radio']:disabled:after {
+  background-color: var(--button-color-alt);
+  cursor: not-allowed;
 }
 
 /* ###################################### */

--- a/chipper/webroot/sdkapp/control.html
+++ b/chipper/webroot/sdkapp/control.html
@@ -9,7 +9,7 @@
       crossorigin="anonymous"
     ></script>
   </head>
-  <body>
+  <body onload="updateControlButtons()">
     <div id="outer">
       <div id="content">
         <h1 class="center">Vector control (beta)</h1>
@@ -25,64 +25,56 @@
 
         <div id="sdkActions">
           <h2 class="center">Camera Feed</h2>
+          <hr class="small-hr">
           <div class="center" id="camStream"></div>
-          <div class="center">
-            <button onclick="showCamStream()">Begin Camera Stream</button>
-            <button onclick="stopCamStream()">Stop Camera Stream</button>
+          <div style="text-align: left;" class="center">
+            <label>
+              <input type="radio" name="cam" id="cam" onclick="showCamStream()">Begin Camera Stream<br>
+            </label>
+            <label>
+              <input type="radio" name="cam" id="cam" onclick="stopCamStream()" checked>Stop Camera Stream<br>
+            </label>
           </div>
           <hr />
 
           <h2 class="center">Behavior Control</h2>
-          <small class="center"
-            >You must assume behavior control before performing any
-            action</small
-          >
-          <div class="center">
-            <button
-              onclick="sendForm('/api-sdk/assume_behavior_control?priority=high')"
-              type="submit"
-            >
-              Assume
-            </button>
-            <button
-              onclick="sendForm('/api-sdk/release_behavior_control')"
-              type="submit"
-            >
-              Release
-            </button>
+          <hr class="small-hr">
+          <small class="center">You must assume behavior control before performing any action</small>
+          <div style="text-align: left;" class="center">
+            <label>
+              <input type="radio" name="control" id="assume_control" onclick="sendForm('/api-sdk/assume_behavior_control?priority=high'); updateControlButtons();">Assume<br>
+            </label>
+            <label>
+              <input type="radio" name="control" id="release_control" onclick="sendForm('/api-sdk/release_behavior_control'); updateControlButtons();" checked>Release<br>
+            </label>
           </div>
-          <hr />
+          <hr/>
 
           <h2 class="center">Move Motors</h2>
-          <div class="center">
-            <button onclick="toggleKeyboard()" type="submit">
-              Toggle Keyboard Controls (unstable)
-            </button>
+          <hr class="small-hr">
+          <small class="center">Toggle Keyboard Controls (unstable) <br> WASD for wheels, R-lift up, F-lift down, T-head up, G-head down</small>
+          <div style="text-align: left;" class="center">
+            <label>
+              <input type="radio" name="keycontrol" id="key_control_on" onclick="toggleKeyboard()" disabled>On<br>
+            </label>
+            <label>
+              <input type="radio" name="keycontrol" id="key_control_off" onclick="toggleKeyboard()" checked disabled>Off<br>
+            </label>
           </div>
-          <div id="keysKey">
-            <small class="center" display="_blank"
-              >Enabled! WASD for wheels, R-lift up, F-lift down, T-head up,
-              G-head down</small
-            >
-          </div>
-          <hr />
+          <hr/>
 
           <h2 class="center">Mirror Mode</h2>
-          <div class="center">
-            <button
-              onclick="sendForm('/api-sdk/mirror_mode?enable=true')"
-              type="submit"
-            >
-              Mirror Mode On
-            </button>
-            <button
-              onclick="sendForm('/api-sdk/mirror_mode?enable=false')"
-              type="submit"
-            >
-              Mirror Mode Off
-            </button>
+          <hr class="small-hr">
+          <div style="text-align: left;" class="center">
+            <label>
+              <input type="radio" name="mirror" id="mirror_on" onclick="sendForm('/api-sdk/mirror_mode?enable=true')" disabled>On<br>
+            </label>
+            <label>
+              <input type="radio" name="mirror" id="mirror_off" onclick="sendForm('/api-sdk/mirror_mode?enable=false')" checked disabled>Off<br>
+            </label>
           </div>
-          <hr />
+          <hr/>
+
           <h2 class="center">Say Text</h2>
             <div class="center">
               <input
@@ -91,6 +83,7 @@
                 id="textSay"
                 type="text"
                 placeholder="Put text here"
+		disabled
               />
             </div>
             <button onclick="sayText()" type="submit">Submit</button>
@@ -111,3 +104,4 @@
     ></iframe>
   </body>
 </html>
+

--- a/chipper/webroot/sdkapp/js/control.js
+++ b/chipper/webroot/sdkapp/js/control.js
@@ -26,6 +26,55 @@ var headIsMovingDown = false;
 var headIsMovingUp = false;
 var headIsStopped = false;
 
+// when pages is closed
+window.onbeforeunload = function() {
+  stopCamStream();
+  useKeyboardControl = false;
+  sendForm("/api-sdk/mirror_mode?enable=false");
+};
+
+// switches items to disabled or enables them
+function updateControlButtons() {
+  const assumeControl = document.getElementById("assume_control");
+  const releaseControl = document.getElementById("release_control");
+  const keyControlOn = document.getElementById("key_control_on");
+  const keyControlOff = document.getElementById("key_control_off");
+  const keyMirrorOn = document.getElementById("mirror_on");
+  const keyMirrorOff = document.getElementById("mirror_off");
+  const textSay = document.getElementById("textSay");
+
+  if (assumeControl.checked) {
+    keyControlOn.disabled = false;
+    keyControlOff.disabled = false;
+    keyMirrorOn.disabled = false;
+    keyMirrorOff.disabled = false;
+    textSay.disabled = false;
+  } else if (releaseControl.checked) {
+    useKeyboardControl = false;
+    keyControlOff.checked = true;
+    keyControlOn.disabled = true;
+    keyControlOff.disabled = true;
+    sendForm("/api-sdk/mirror_mode?enable=false");
+    keyMirrorOff.checked = true;
+    keyMirrorOn.disabled = true;
+    keyMirrorOff.disabled = true;
+    textSay.disabled = true;
+  }
+}
+
+// Add event listener to activate keyControlOff when textSay receives the focus
+document.addEventListener('DOMContentLoaded', function() {
+  const textSay = document.getElementById("textSay");
+  const keyControlOff = document.getElementById("key_control_off");
+
+  textSay.addEventListener('focus', function() {
+    //keyControlOff.disabled = false;
+    keyControlOff.checked = true;
+    useKeyboardControl = false;
+  });
+});
+
+
 function toggleKeyboard() {
   if (useKeyboardControl == false) {
     useKeyboardControl = true;


### PR DESCRIPTION
I have changed the buttons on the Vector control (beta) page to radiobuttons to keep them in the styleguide and are enabled or disabled depending on their function.
![Screenshot_20240624_072649](https://github.com/kercre123/wire-pod/assets/75612866/458d0b48-4757-4f72-953d-e879c39a4c0f)
