### PR TITLE
Fix "America/Sao_Paolo" and "America/Buenos_A>" typos

### DIFF
--- a/chipper/webroot/sdkapp/settings.html
+++ b/chipper/webroot/sdkapp/settings.html
@@ -333,7 +333,7 @@
             <option value="America/New_York">America/New_York</option>
             <option value="America/Argentina/Buenos_Aires">America/Argentina/Buenos_A>
             <option value="America/Santiago">America/Santiago</option>
-            <option value="America/Sao_Paolo">America/Sao_Paolo</option>
+            <option value="America/Sao_Paolo">America/Sao_Paulo</option>
             <option value="America/St_Johns">America/St_Johns</option>
             <option value="GMT">GMT</option>
             <option value="Europe/Lisbon">Europe/Lisbon</option>

--- a/chipper/webroot/sdkapp/settings.html
+++ b/chipper/webroot/sdkapp/settings.html
@@ -333,7 +333,7 @@
             <option value="America/New_York">America/New_York</option>
             <option value="America/Argentina/Buenos_Aires">America/Argentina/Buenos_A>
             <option value="America/Santiago">America/Santiago</option>
-            <option value="America/Sao_Paolo">America/Sao_Paulo</option>
+            <option value="America/Sao_Paulo">America/Sao_Paulo</option>
             <option value="America/St_Johns">America/St_Johns</option>
             <option value="GMT">GMT</option>
             <option value="Europe/Lisbon">Europe/Lisbon</option>

--- a/chipper/webroot/sdkapp/settings.html
+++ b/chipper/webroot/sdkapp/settings.html
@@ -331,7 +331,7 @@
             <option value="America/Chicago">America/Chicago</option>
             <option value="America/Bogota">America/Bogota</option>
             <option value="America/New_York">America/New_York</option>
-            <option value="America/Argentina/Buenos_Aires">America/Argentina/Buenos_A>
+            <option value="America/Argentina/Buenos_Aires">America/Argentina/Buenos_Aires</option>
             <option value="America/Santiago">America/Santiago</option>
             <option value="America/Sao_Paulo">America/Sao_Paulo</option>
             <option value="America/St_Johns">America/St_Johns</option>


### PR DESCRIPTION
Closes #360.

Fixes two typos in the timezones.