### PR TITLE
Display Image on Vector Screen

### DIFF
--- a/chipper/pkg/wirepod/sdkapp/server.go
+++ b/chipper/pkg/wirepod/sdkapp/server.go
@@ -147,13 +147,6 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 
 		defer imgPath.Close()
 
-		solidFaceBytes := make([]byte, 17664*10) // 17664 pixels, 3 bytes por pixel
-		for i := 0; i < len(solidFaceBytes); i += 3 {
-			solidFaceBytes[i] = 255 // R
-			solidFaceBytes[i+1] = 0 // G
-			solidFaceBytes[i+2] = 0 // B
-		}
-
 		img, _, err := image.Decode(imgPath)
 		if err != nil {
 			http.Error(w, "Error reading image: "+err.Error(), http.StatusInternalServerError)
@@ -185,7 +178,7 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Reads the image and handles possible errors
-		//faceBytes, err := rgbToBytes(rgbValues)
+		faceBytes, err := rgbToBytes(rgbValues)
 		if err != nil {
 			http.Error(w, "Error reading image: "+err.Error(), http.StatusInternalServerError)
 			return
@@ -199,7 +192,7 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 
 		// call DisplayFaceImageRGB e handle error
 		resp, err := robot.Conn.DisplayFaceImageRGB(ctx, &vectorpb.DisplayFaceImageRGBRequest{
-			FaceData:         solidFaceBytes,
+			FaceData:         faceBytes,
 			DurationMs:       uint32(duration),
 			InterruptRunning: true,
 		})

--- a/chipper/pkg/wirepod/sdkapp/server.go
+++ b/chipper/pkg/wirepod/sdkapp/server.go
@@ -149,9 +149,9 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 
 		solidFaceBytes := make([]byte, 17664*3) // 17664 pixels, 3 bytes por pixel
 		for i := 0; i < len(solidFaceBytes); i += 3 {
-			solidFaceBytes[i] = 0     // R
-			solidFaceBytes[i+1] = 255 // G
-			solidFaceBytes[i+2] = 0   // B
+			solidFaceBytes[i] = 255 // R
+			solidFaceBytes[i+1] = 0 // G
+			solidFaceBytes[i+2] = 0 // B
 		}
 
 		img, _, err := image.Decode(imgPath)

--- a/chipper/pkg/wirepod/sdkapp/server.go
+++ b/chipper/pkg/wirepod/sdkapp/server.go
@@ -178,7 +178,7 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Reads the image and handles possible errors
-		faceBytes, err := rgbToBytes(rgbValues)
+		faceBytes, err := imageToBytes(img)
 		if err != nil {
 			http.Error(w, "Error reading image: "+err.Error(), http.StatusInternalServerError)
 			return
@@ -648,6 +648,25 @@ func rgbToBytes(rgbValues [][][3]uint8) ([]byte, error) {
 			buffer.WriteByte(pixel[0]) // R
 			buffer.WriteByte(pixel[1]) // G
 			buffer.WriteByte(pixel[2]) // B
+		}
+	}
+
+	return buffer.Bytes(), nil
+}
+func imageToBytes(img image.Image) ([]byte, error) {
+	bounds := img.Bounds()
+	var buffer bytes.Buffer
+
+	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			// Obtém a cor do pixel
+			c := img.At(x, y)
+			r, g, b, _ := c.RGBA() // Ignorando o valor Alpha
+
+			// Converte de uint32 para uint8
+			buffer.WriteByte(uint8(r >> 8))
+			buffer.WriteByte(uint8(g >> 8))
+			buffer.WriteByte(uint8(b >> 8))
 		}
 	}
 

--- a/chipper/pkg/wirepod/sdkapp/server.go
+++ b/chipper/pkg/wirepod/sdkapp/server.go
@@ -3,7 +3,6 @@ package sdkapp
 import (
 	"bytes"
 	"context"
-	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"image"
@@ -643,12 +642,11 @@ func rgbToBytes(rgbValues [][][3]uint8) ([]byte, error) {
 
 	for _, row := range rgbValues {
 		for _, pixel := range row {
-			err := binary.Write(&buffer, binary.LittleEndian, pixel)
-			if err != nil {
-				return nil, err
-			}
+			// Adiciona diretamente os valores R, G e B no buffer
+			buffer.WriteByte(pixel[2]) // R
+			buffer.WriteByte(pixel[1]) // G
+			buffer.WriteByte(pixel[0]) // B
 		}
-
 	}
 
 	return buffer.Bytes(), nil

--- a/chipper/pkg/wirepod/sdkapp/server.go
+++ b/chipper/pkg/wirepod/sdkapp/server.go
@@ -147,7 +147,7 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 
 		defer imgPath.Close()
 
-		solidFaceBytes := make([]byte, 17664*1) // 17664 pixels, 3 bytes por pixel
+		solidFaceBytes := make([]byte, 17664*10) // 17664 pixels, 3 bytes por pixel
 		for i := 0; i < len(solidFaceBytes); i += 3 {
 			solidFaceBytes[i] = 255 // R
 			solidFaceBytes[i+1] = 0 // G

--- a/chipper/pkg/wirepod/sdkapp/server.go
+++ b/chipper/pkg/wirepod/sdkapp/server.go
@@ -20,7 +20,6 @@ import (
 	"github.com/kercre123/wire-pod/chipper/pkg/logger"
 	"github.com/kercre123/wire-pod/chipper/pkg/scripting"
 	"github.com/kercre123/wire-pod/chipper/pkg/vars"
-	"github.com/nfnt/resize"
 )
 
 var serverFiles string = "./webroot/sdkapp"
@@ -151,7 +150,7 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Error reading image: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
-		resizedImg := resize.Resize(184, 96, img, resize.Lanczos3)
+		resizedImg := resizeImage(img, 184, 96)
 		bounds := resizedImg.Bounds()
 
 		rgbValues := make([][][3]uint8, bounds.Dy()) // height
@@ -652,4 +651,25 @@ func rgbToBytes(rgbValues [][][3]uint8) ([]byte, error) {
 	}
 
 	return buffer.Bytes(), nil
+}
+
+func resizeImage(original image.Image, width, height int) image.Image {
+	if width <= 0 || height <= 0 {
+		return original
+	}
+
+	newImage := image.NewRGBA(image.Rect(0, 0, width, height))
+
+	scaleX := float64(original.Bounds().Dx()) / float64(width)
+	scaleY := float64(original.Bounds().Dy()) / float64(height)
+
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			srcX := int(float64(x) * scaleX)
+			srcY := int(float64(y) * scaleY)
+			newImage.Set(x, y, original.At(srcX, srcY))
+		}
+	}
+
+	return newImage
 }

--- a/chipper/pkg/wirepod/sdkapp/server.go
+++ b/chipper/pkg/wirepod/sdkapp/server.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"image"
 	"image/jpeg"
-	"image/png"
 	"io"
 	"net/http"
 	"os"
@@ -179,14 +178,12 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 		// }
 
 		// Reads the image and handles possible errors
-		var buf bytes.Buffer
-		err = png.Encode(&buf, img)
+		faceBytes, err := imageToBytes(img)
 		if err != nil {
 			http.Error(w, "Error reading image: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
 
-		faceBytes := buf.Bytes()
 		ctx := r.Context()
 		ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
 		defer cancel()

--- a/chipper/pkg/wirepod/sdkapp/server.go
+++ b/chipper/pkg/wirepod/sdkapp/server.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"image"
 	"image/jpeg"
+	"image/png"
 	"io"
 	"net/http"
 	"os"
@@ -154,36 +155,38 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		//resizedImg := resizeImage(img, 184, 96)
 
-		bounds := img.Bounds()
+		// bounds := img.Bounds()
 
-		rgbValues := make([][][3]uint8, bounds.Dy()) // height
+		// rgbValues := make([][][3]uint8, bounds.Dy()) // height
 
-		for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
-			rgbRow := make([][3]uint8, bounds.Dx()) // width
+		// for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+		// 	rgbRow := make([][3]uint8, bounds.Dx()) // width
 
-			for x := bounds.Min.X; x < bounds.Max.X; x++ {
-				//get current pixel color
-				f := img.At(x, y)
+		// 	for x := bounds.Min.X; x < bounds.Max.X; x++ {
+		// 		//get current pixel color
+		// 		f := img.At(x, y)
 
-				r, g, b, _ := f.RGBA()
-				r8 := uint8(r >> 8)
-				g8 := uint8(g >> 8)
-				b8 := uint8(b >> 8)
+		// 		r, g, b, _ := f.RGBA()
+		// 		r8 := uint8(r >> 8)
+		// 		g8 := uint8(g >> 8)
+		// 		b8 := uint8(b >> 8)
 
-				//store RGB values
-				rgbRow[x] = [3]uint8{r8, g8, b8}
-			}
+		// 		//store RGB values
+		// 		rgbRow[x] = [3]uint8{r8, g8, b8}
+		// 	}
 
-			rgbValues[y] = rgbRow
-		}
+		// 	rgbValues[y] = rgbRow
+		// }
 
 		// Reads the image and handles possible errors
-		faceBytes, err := imageToBytes(img)
+		var buf bytes.Buffer
+		err = png.Encode(&buf, img)
 		if err != nil {
 			http.Error(w, "Error reading image: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
 
+		faceBytes := buf.Bytes()
 		ctx := r.Context()
 		ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
 		defer cancel()

--- a/chipper/pkg/wirepod/sdkapp/server.go
+++ b/chipper/pkg/wirepod/sdkapp/server.go
@@ -175,7 +175,7 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 			rgbValues[y] = rgbRow
 		}
 
-		// Lê a imagem e trata possíveis erros
+		// Reads the image and handles possible errors
 		faceBytes, err := rgbToBytes(rgbValues)
 		if err != nil {
 			http.Error(w, "Error reading image: "+err.Error(), http.StatusInternalServerError)
@@ -186,14 +186,13 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 		ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
 		defer cancel()
 
-		// Defina a duração e o bloqueio
-		duration := 3000 // Duração em milissegundos
+		duration := 3000
 
-		// Chamada da função DisplayFaceImageRGB e tratamento de erro
+		// call DisplayFaceImageRGB e handle error
 		resp, err := robot.Conn.DisplayFaceImageRGB(ctx, &vectorpb.DisplayFaceImageRGBRequest{
-			FaceData:         faceBytes,        // Certifique-se de que este campo é exportado
-			DurationMs:       uint32(duration), // Certifique-se de que este campo é exportado
-			InterruptRunning: true,             // Certifique-se de que este campo é exportado
+			FaceData:         faceBytes,
+			DurationMs:       uint32(duration),
+			InterruptRunning: true,
 		})
 
 		if err != nil {
@@ -201,7 +200,6 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// Responda com um status de sucesso
 		fmt.Fprintf(w, "Face image displayed successfully: %+v", resp)
 		return
 
@@ -644,10 +642,10 @@ func rgbToBytes(rgbValues [][][3]uint8) ([]byte, error) {
 
 	for _, row := range rgbValues {
 		for _, pixel := range row {
-			// Adiciona diretamente os valores R, G e B no buffer
-			buffer.WriteByte(pixel[2]) // R
+			// Directly add the R, G and B values ​​to the buffer
+			buffer.WriteByte(pixel[0]) // R
 			buffer.WriteByte(pixel[1]) // G
-			buffer.WriteByte(pixel[0]) // B
+			buffer.WriteByte(pixel[2]) // B
 		}
 	}
 

--- a/chipper/pkg/wirepod/sdkapp/server.go
+++ b/chipper/pkg/wirepod/sdkapp/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kercre123/wire-pod/chipper/pkg/logger"
 	"github.com/kercre123/wire-pod/chipper/pkg/scripting"
 	"github.com/kercre123/wire-pod/chipper/pkg/vars"
+	"github.com/nfnt/resize"
 )
 
 var serverFiles string = "./webroot/sdkapp"
@@ -150,7 +151,8 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Error reading image: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
-		bounds := img.Bounds()
+		resizedImg := resize.Resize(184, 96, img, resize.Lanczos3)
+		bounds := resizedImg.Bounds()
 
 		rgbValues := make([][][3]uint8, bounds.Dy()) // height
 
@@ -643,9 +645,9 @@ func rgbToBytes(rgbValues [][][3]uint8) ([]byte, error) {
 	for _, row := range rgbValues {
 		for _, pixel := range row {
 			// Adiciona diretamente os valores R, G e B no buffer
-			buffer.WriteByte(pixel[2]) // R
+			buffer.WriteByte(pixel[0]) // R
 			buffer.WriteByte(pixel[1]) // G
-			buffer.WriteByte(pixel[0]) // B
+			buffer.WriteByte(pixel[2]) // B
 		}
 	}
 

--- a/chipper/pkg/wirepod/sdkapp/server.go
+++ b/chipper/pkg/wirepod/sdkapp/server.go
@@ -147,7 +147,7 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 
 		defer imgPath.Close()
 
-		solidFaceBytes := make([]byte, 17664*3) // 17664 pixels, 3 bytes por pixel
+		solidFaceBytes := make([]byte, 17664*1) // 17664 pixels, 3 bytes por pixel
 		for i := 0; i < len(solidFaceBytes); i += 3 {
 			solidFaceBytes[i] = 255 // R
 			solidFaceBytes[i+1] = 0 // G

--- a/chipper/pkg/wirepod/sdkapp/server.go
+++ b/chipper/pkg/wirepod/sdkapp/server.go
@@ -151,6 +151,7 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		resizedImg := resizeImage(img, 184, 96)
+
 		bounds := resizedImg.Bounds()
 
 		rgbValues := make([][][3]uint8, bounds.Dy()) // height
@@ -160,7 +161,7 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 
 			for x := bounds.Min.X; x < bounds.Max.X; x++ {
 				//get current pixel color
-				f := img.At(x, y)
+				f := resizedImg.At(x, y)
 
 				r, g, b, _ := f.RGBA()
 				r8 := uint8(r >> 8)

--- a/chipper/pkg/wirepod/sdkapp/server.go
+++ b/chipper/pkg/wirepod/sdkapp/server.go
@@ -150,9 +150,9 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Error reading image: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
-		resizedImg := resizeImage(img, 184, 96)
+		//resizedImg := resizeImage(img, 184, 96)
 
-		bounds := resizedImg.Bounds()
+		bounds := img.Bounds()
 
 		rgbValues := make([][][3]uint8, bounds.Dy()) // height
 
@@ -161,7 +161,7 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 
 			for x := bounds.Min.X; x < bounds.Max.X; x++ {
 				//get current pixel color
-				f := resizedImg.At(x, y)
+				f := img.At(x, y)
 
 				r, g, b, _ := f.RGBA()
 				r8 := uint8(r >> 8)

--- a/chipper/pkg/wirepod/sdkapp/server.go
+++ b/chipper/pkg/wirepod/sdkapp/server.go
@@ -644,9 +644,9 @@ func rgbToBytes(rgbValues [][][3]uint8) ([]byte, error) {
 	for _, row := range rgbValues {
 		for _, pixel := range row {
 			// Adiciona diretamente os valores R, G e B no buffer
-			buffer.WriteByte(pixel[0]) // R
+			buffer.WriteByte(pixel[2]) // R
 			buffer.WriteByte(pixel[1]) // G
-			buffer.WriteByte(pixel[2]) // B
+			buffer.WriteByte(pixel[0]) // B
 		}
 	}
 

--- a/chipper/pkg/wirepod/sdkapp/server.go
+++ b/chipper/pkg/wirepod/sdkapp/server.go
@@ -176,7 +176,7 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Reads the image and handles possible errors
-		faceBytes, err := rgbToBytes(rgbValues)
+		//faceBytes, err := rgbToBytes(rgbValues)
 		if err != nil {
 			http.Error(w, "Error reading image: "+err.Error(), http.StatusInternalServerError)
 			return
@@ -190,7 +190,7 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 
 		// call DisplayFaceImageRGB e handle error
 		resp, err := robot.Conn.DisplayFaceImageRGB(ctx, &vectorpb.DisplayFaceImageRGBRequest{
-			FaceData:         faceBytes,
+			FaceData:         rgbValues,
 			DurationMs:       uint32(duration),
 			InterruptRunning: true,
 		})


### PR DESCRIPTION
@kercre123  Hello, I'm trying to implement DisplayFaceImageRGBRequest from [vector-go-sdk](https://github.com/fforchino/vector-go-sdk/tree/62168f3595d67ae0bf24103a9fe1fc5f2eb9b85c). I was able to send an image file with a POST request to http://xxx.xxx.xxx.xxx/api-sdk/display_image?serial=xxxxxx, but the image is displayed incorrectly.

Can you help with this if it is relevant to the project?

I tryed: 

- resize the image
- Convert to RGB before convert to bytes and send
- Send without convert to RGB
- Send a solid image green (displayed green with white noise)
- JPEG and PNG

![image](https://github.com/user-attachments/assets/9432b24e-b9ca-4f40-8fce-d840b7a7b549)
