### PR TITLE
Playing Audio (WAV) through Vector

### DIFF
--- a/chipper/pkg/wirepod/sdkapp/server.go
+++ b/chipper/pkg/wirepod/sdkapp/server.go
@@ -147,13 +147,6 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 
 		defer imgPath.Close()
 
-		solidFaceBytes := make([]byte, 17664*10) // 17664 pixels, 3 bytes por pixel
-		for i := 0; i < len(solidFaceBytes); i += 3 {
-			solidFaceBytes[i] = 255 // R
-			solidFaceBytes[i+1] = 0 // G
-			solidFaceBytes[i+2] = 0 // B
-		}
-
 		img, _, err := image.Decode(imgPath)
 		if err != nil {
 			http.Error(w, "Error reading image: "+err.Error(), http.StatusInternalServerError)
@@ -185,7 +178,7 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Reads the image and handles possible errors
-		//faceBytes, err := rgbToBytes(rgbValues)
+		faceBytes, err := rgbToBytes(rgbValues)
 		if err != nil {
 			http.Error(w, "Error reading image: "+err.Error(), http.StatusInternalServerError)
 			return
@@ -199,7 +192,7 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 
 		// call DisplayFaceImageRGB e handle error
 		resp, err := robot.Conn.DisplayFaceImageRGB(ctx, &vectorpb.DisplayFaceImageRGBRequest{
-			FaceData:         solidFaceBytes,
+			FaceData:         faceBytes,
 			DurationMs:       uint32(duration),
 			InterruptRunning: true,
 		})

--- a/chipper/pkg/wirepod/sdkapp/server.go
+++ b/chipper/pkg/wirepod/sdkapp/server.go
@@ -149,9 +149,9 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 
 		solidFaceBytes := make([]byte, 17664*3) // 17664 pixels, 3 bytes por pixel
 		for i := 0; i < len(solidFaceBytes); i += 3 {
-			solidFaceBytes[i] = 0     // R
-			solidFaceBytes[i+1] = 255 // G
-			solidFaceBytes[i+2] = 0   // B
+			solidFaceBytes[i] = 255 // R
+			solidFaceBytes[i+1] = 0 // G
+			solidFaceBytes[i+2] = 0 // B
 		}
 
 		img, _, err := image.Decode(imgPath)

--- a/chipper/pkg/wirepod/sdkapp/server.go
+++ b/chipper/pkg/wirepod/sdkapp/server.go
@@ -178,7 +178,7 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Reads the image and handles possible errors
-		faceBytes, err := rgbToBytes(rgbValues)
+		faceBytes, err := imageToBytes(img)
 		if err != nil {
 			http.Error(w, "Error reading image: "+err.Error(), http.StatusInternalServerError)
 			return
@@ -648,6 +648,25 @@ func rgbToBytes(rgbValues [][][3]uint8) ([]byte, error) {
 			buffer.WriteByte(pixel[0]) // R
 			buffer.WriteByte(pixel[1]) // G
 			buffer.WriteByte(pixel[2]) // B
+		}
+	}
+
+	return buffer.Bytes(), nil
+}
+func imageToBytes(img image.Image) ([]byte, error) {
+	bounds := img.Bounds()
+	var buffer bytes.Buffer
+
+	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			// Obtém a cor do pixel
+			c := img.At(x, y)
+			r, g, b, _ := c.RGBA() // Ignorando o valor Alpha
+
+			// Converte de uint32 para uint8
+			buffer.WriteByte(uint8(r >> 8))
+			buffer.WriteByte(uint8(g >> 8))
+			buffer.WriteByte(uint8(b >> 8))
 		}
 	}
 

--- a/chipper/pkg/wirepod/sdkapp/server.go
+++ b/chipper/pkg/wirepod/sdkapp/server.go
@@ -3,7 +3,6 @@ package sdkapp
 import (
 	"bytes"
 	"context"
-	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"image"
@@ -643,12 +642,11 @@ func rgbToBytes(rgbValues [][][3]uint8) ([]byte, error) {
 
 	for _, row := range rgbValues {
 		for _, pixel := range row {
-			err := binary.Write(&buffer, binary.LittleEndian, pixel)
-			if err != nil {
-				return nil, err
-			}
+			// Adiciona diretamente os valores R, G e B no buffer
+			buffer.WriteByte(pixel[2]) // R
+			buffer.WriteByte(pixel[1]) // G
+			buffer.WriteByte(pixel[0]) // B
 		}
-
 	}
 
 	return buffer.Bytes(), nil

--- a/chipper/pkg/wirepod/sdkapp/server.go
+++ b/chipper/pkg/wirepod/sdkapp/server.go
@@ -147,7 +147,7 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 
 		defer imgPath.Close()
 
-		solidFaceBytes := make([]byte, 17664*1) // 17664 pixels, 3 bytes por pixel
+		solidFaceBytes := make([]byte, 17664*10) // 17664 pixels, 3 bytes por pixel
 		for i := 0; i < len(solidFaceBytes); i += 3 {
 			solidFaceBytes[i] = 255 // R
 			solidFaceBytes[i+1] = 0 // G

--- a/chipper/pkg/wirepod/sdkapp/server.go
+++ b/chipper/pkg/wirepod/sdkapp/server.go
@@ -20,7 +20,6 @@ import (
 	"github.com/kercre123/wire-pod/chipper/pkg/logger"
 	"github.com/kercre123/wire-pod/chipper/pkg/scripting"
 	"github.com/kercre123/wire-pod/chipper/pkg/vars"
-	"github.com/nfnt/resize"
 )
 
 var serverFiles string = "./webroot/sdkapp"
@@ -151,7 +150,7 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Error reading image: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
-		resizedImg := resize.Resize(184, 96, img, resize.Lanczos3)
+		resizedImg := resizeImage(img, 184, 96)
 		bounds := resizedImg.Bounds()
 
 		rgbValues := make([][][3]uint8, bounds.Dy()) // height
@@ -652,4 +651,25 @@ func rgbToBytes(rgbValues [][][3]uint8) ([]byte, error) {
 	}
 
 	return buffer.Bytes(), nil
+}
+
+func resizeImage(original image.Image, width, height int) image.Image {
+	if width <= 0 || height <= 0 {
+		return original
+	}
+
+	newImage := image.NewRGBA(image.Rect(0, 0, width, height))
+
+	scaleX := float64(original.Bounds().Dx()) / float64(width)
+	scaleY := float64(original.Bounds().Dy()) / float64(height)
+
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			srcX := int(float64(x) * scaleX)
+			srcY := int(float64(y) * scaleY)
+			newImage.Set(x, y, original.At(srcX, srcY))
+		}
+	}
+
+	return newImage
 }

--- a/chipper/pkg/wirepod/sdkapp/server.go
+++ b/chipper/pkg/wirepod/sdkapp/server.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"image"
 	"image/jpeg"
-	"image/png"
 	"io"
 	"net/http"
 	"os"
@@ -179,14 +178,12 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 		// }
 
 		// Reads the image and handles possible errors
-		var buf bytes.Buffer
-		err = png.Encode(&buf, img)
+		faceBytes, err := imageToBytes(img)
 		if err != nil {
 			http.Error(w, "Error reading image: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
 
-		faceBytes := buf.Bytes()
 		ctx := r.Context()
 		ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
 		defer cancel()

--- a/chipper/pkg/wirepod/sdkapp/server.go
+++ b/chipper/pkg/wirepod/sdkapp/server.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"image"
 	"image/jpeg"
+	"image/png"
 	"io"
 	"net/http"
 	"os"
@@ -154,36 +155,38 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		//resizedImg := resizeImage(img, 184, 96)
 
-		bounds := img.Bounds()
+		// bounds := img.Bounds()
 
-		rgbValues := make([][][3]uint8, bounds.Dy()) // height
+		// rgbValues := make([][][3]uint8, bounds.Dy()) // height
 
-		for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
-			rgbRow := make([][3]uint8, bounds.Dx()) // width
+		// for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+		// 	rgbRow := make([][3]uint8, bounds.Dx()) // width
 
-			for x := bounds.Min.X; x < bounds.Max.X; x++ {
-				//get current pixel color
-				f := img.At(x, y)
+		// 	for x := bounds.Min.X; x < bounds.Max.X; x++ {
+		// 		//get current pixel color
+		// 		f := img.At(x, y)
 
-				r, g, b, _ := f.RGBA()
-				r8 := uint8(r >> 8)
-				g8 := uint8(g >> 8)
-				b8 := uint8(b >> 8)
+		// 		r, g, b, _ := f.RGBA()
+		// 		r8 := uint8(r >> 8)
+		// 		g8 := uint8(g >> 8)
+		// 		b8 := uint8(b >> 8)
 
-				//store RGB values
-				rgbRow[x] = [3]uint8{r8, g8, b8}
-			}
+		// 		//store RGB values
+		// 		rgbRow[x] = [3]uint8{r8, g8, b8}
+		// 	}
 
-			rgbValues[y] = rgbRow
-		}
+		// 	rgbValues[y] = rgbRow
+		// }
 
 		// Reads the image and handles possible errors
-		faceBytes, err := imageToBytes(img)
+		var buf bytes.Buffer
+		err = png.Encode(&buf, img)
 		if err != nil {
 			http.Error(w, "Error reading image: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
 
+		faceBytes := buf.Bytes()
 		ctx := r.Context()
 		ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
 		defer cancel()

--- a/chipper/pkg/wirepod/sdkapp/server.go
+++ b/chipper/pkg/wirepod/sdkapp/server.go
@@ -175,7 +175,7 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 			rgbValues[y] = rgbRow
 		}
 
-		// Lê a imagem e trata possíveis erros
+		// Reads the image and handles possible errors
 		faceBytes, err := rgbToBytes(rgbValues)
 		if err != nil {
 			http.Error(w, "Error reading image: "+err.Error(), http.StatusInternalServerError)
@@ -186,14 +186,13 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 		ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
 		defer cancel()
 
-		// Defina a duração e o bloqueio
-		duration := 3000 // Duração em milissegundos
+		duration := 3000
 
-		// Chamada da função DisplayFaceImageRGB e tratamento de erro
+		// call DisplayFaceImageRGB e handle error
 		resp, err := robot.Conn.DisplayFaceImageRGB(ctx, &vectorpb.DisplayFaceImageRGBRequest{
-			FaceData:         faceBytes,        // Certifique-se de que este campo é exportado
-			DurationMs:       uint32(duration), // Certifique-se de que este campo é exportado
-			InterruptRunning: true,             // Certifique-se de que este campo é exportado
+			FaceData:         faceBytes,
+			DurationMs:       uint32(duration),
+			InterruptRunning: true,
 		})
 
 		if err != nil {
@@ -201,7 +200,6 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// Responda com um status de sucesso
 		fmt.Fprintf(w, "Face image displayed successfully: %+v", resp)
 		return
 
@@ -644,10 +642,10 @@ func rgbToBytes(rgbValues [][][3]uint8) ([]byte, error) {
 
 	for _, row := range rgbValues {
 		for _, pixel := range row {
-			// Adiciona diretamente os valores R, G e B no buffer
-			buffer.WriteByte(pixel[2]) // R
+			// Directly add the R, G and B values ​​to the buffer
+			buffer.WriteByte(pixel[0]) // R
 			buffer.WriteByte(pixel[1]) // G
-			buffer.WriteByte(pixel[0]) // B
+			buffer.WriteByte(pixel[2]) // B
 		}
 	}
 

--- a/chipper/pkg/wirepod/sdkapp/server.go
+++ b/chipper/pkg/wirepod/sdkapp/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kercre123/wire-pod/chipper/pkg/logger"
 	"github.com/kercre123/wire-pod/chipper/pkg/scripting"
 	"github.com/kercre123/wire-pod/chipper/pkg/vars"
+	"github.com/nfnt/resize"
 )
 
 var serverFiles string = "./webroot/sdkapp"
@@ -150,7 +151,8 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Error reading image: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
-		bounds := img.Bounds()
+		resizedImg := resize.Resize(184, 96, img, resize.Lanczos3)
+		bounds := resizedImg.Bounds()
 
 		rgbValues := make([][][3]uint8, bounds.Dy()) // height
 
@@ -643,9 +645,9 @@ func rgbToBytes(rgbValues [][][3]uint8) ([]byte, error) {
 	for _, row := range rgbValues {
 		for _, pixel := range row {
 			// Adiciona diretamente os valores R, G e B no buffer
-			buffer.WriteByte(pixel[2]) // R
+			buffer.WriteByte(pixel[0]) // R
 			buffer.WriteByte(pixel[1]) // G
-			buffer.WriteByte(pixel[0]) // B
+			buffer.WriteByte(pixel[2]) // B
 		}
 	}
 

--- a/chipper/pkg/wirepod/sdkapp/server.go
+++ b/chipper/pkg/wirepod/sdkapp/server.go
@@ -167,7 +167,7 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 		audioClient.SendMsg(&vectorpb.ExternalAudioStreamRequest{
 			AudioRequestType: &vectorpb.ExternalAudioStreamRequest_AudioStreamPrepare{
 				AudioStreamPrepare: &vectorpb.ExternalAudioStreamPrepare{
-					AudioFrameRate: 16000,
+					AudioFrameRate: 8000,
 					AudioVolume:    uint32(100),
 				},
 			},
@@ -182,7 +182,7 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 					},
 				},
 			})
-			time.Sleep(time.Millisecond * 30)
+			time.Sleep(time.Millisecond * 60)
 		}
 
 		audioClient.SendMsg(&vectorpb.ExternalAudioStreamRequest{

--- a/chipper/pkg/wirepod/sdkapp/server.go
+++ b/chipper/pkg/wirepod/sdkapp/server.go
@@ -147,7 +147,7 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 
 		defer imgPath.Close()
 
-		solidFaceBytes := make([]byte, 17664*3) // 17664 pixels, 3 bytes por pixel
+		solidFaceBytes := make([]byte, 17664*1) // 17664 pixels, 3 bytes por pixel
 		for i := 0; i < len(solidFaceBytes); i += 3 {
 			solidFaceBytes[i] = 255 // R
 			solidFaceBytes[i+1] = 0 // G

--- a/chipper/pkg/wirepod/sdkapp/server.go
+++ b/chipper/pkg/wirepod/sdkapp/server.go
@@ -151,6 +151,7 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		resizedImg := resizeImage(img, 184, 96)
+
 		bounds := resizedImg.Bounds()
 
 		rgbValues := make([][][3]uint8, bounds.Dy()) // height
@@ -160,7 +161,7 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 
 			for x := bounds.Min.X; x < bounds.Max.X; x++ {
 				//get current pixel color
-				f := img.At(x, y)
+				f := resizedImg.At(x, y)
 
 				r, g, b, _ := f.RGBA()
 				r8 := uint8(r >> 8)

--- a/chipper/pkg/wirepod/sdkapp/server.go
+++ b/chipper/pkg/wirepod/sdkapp/server.go
@@ -150,9 +150,9 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Error reading image: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
-		resizedImg := resizeImage(img, 184, 96)
+		//resizedImg := resizeImage(img, 184, 96)
 
-		bounds := resizedImg.Bounds()
+		bounds := img.Bounds()
 
 		rgbValues := make([][][3]uint8, bounds.Dy()) // height
 
@@ -161,7 +161,7 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 
 			for x := bounds.Min.X; x < bounds.Max.X; x++ {
 				//get current pixel color
-				f := resizedImg.At(x, y)
+				f := img.At(x, y)
 
 				r, g, b, _ := f.RGBA()
 				r8 := uint8(r >> 8)

--- a/chipper/pkg/wirepod/sdkapp/server.go
+++ b/chipper/pkg/wirepod/sdkapp/server.go
@@ -644,9 +644,9 @@ func rgbToBytes(rgbValues [][][3]uint8) ([]byte, error) {
 	for _, row := range rgbValues {
 		for _, pixel := range row {
 			// Adiciona diretamente os valores R, G e B no buffer
-			buffer.WriteByte(pixel[0]) // R
+			buffer.WriteByte(pixel[2]) // R
 			buffer.WriteByte(pixel[1]) // G
-			buffer.WriteByte(pixel[2]) // B
+			buffer.WriteByte(pixel[0]) // B
 		}
 	}
 

--- a/chipper/pkg/wirepod/sdkapp/server.go
+++ b/chipper/pkg/wirepod/sdkapp/server.go
@@ -176,7 +176,7 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Reads the image and handles possible errors
-		faceBytes, err := rgbToBytes(rgbValues)
+		//faceBytes, err := rgbToBytes(rgbValues)
 		if err != nil {
 			http.Error(w, "Error reading image: "+err.Error(), http.StatusInternalServerError)
 			return
@@ -190,7 +190,7 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 
 		// call DisplayFaceImageRGB e handle error
 		resp, err := robot.Conn.DisplayFaceImageRGB(ctx, &vectorpb.DisplayFaceImageRGBRequest{
-			FaceData:         faceBytes,
+			FaceData:         rgbValues,
 			DurationMs:       uint32(duration),
 			InterruptRunning: true,
 		})

--- a/chipper/webroot/js/play_audio.js
+++ b/chipper/webroot/js/play_audio.js
@@ -1,0 +1,125 @@
+
+//Convert the WAV frame rate on the client machine and send the WAV file to be processed at /api-sdk/play_sound
+
+let processedAudioBlob = null; 
+
+document.getElementById('fileInput').addEventListener('change', async () => {
+    const fileInput = document.getElementById('fileInput');
+    if (!fileInput.files.length) {
+        alert('Please, select a WAV file');
+        return;
+    }
+
+    const file = fileInput.files[0];
+    const arrayBuffer = await file.arrayBuffer();
+    const audioContext = new (window.AudioContext || window.webkitAudioContext)();
+
+    try {
+        const audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
+        
+        // adjust frame rate to 8000 Hz
+        const newSampleRate = 8000;
+        const newLength = Math.round(audioBuffer.length * newSampleRate / audioBuffer.sampleRate);
+        const newBuffer = audioContext.createBuffer(audioBuffer.numberOfChannels, newLength, newSampleRate);
+
+        for (let channel = 0; channel < audioBuffer.numberOfChannels; channel++) {
+            const oldData = audioBuffer.getChannelData(channel);
+            const newData = newBuffer.getChannelData(channel);
+
+            for (let i = 0; i < newLength; i++) {
+                const oldIndex = i * audioBuffer.sampleRate / newSampleRate;
+                const index0 = Math.floor(oldIndex);
+                const index1 = Math.min(index0 + 1, oldData.length - 1);
+                const fraction = oldIndex - index0;
+
+                newData[i] = oldData[index0] * (1 - fraction) + oldData[index1] * fraction; 
+            }
+        }
+
+        // Create a new WAV file
+        processedAudioBlob = await bufferToWave(newBuffer);
+        const url = URL.createObjectURL(processedAudioBlob);
+
+        // play processed audio
+        const audioOutput = document.getElementById('audioOutput');
+        audioOutput.src = url;
+        audioOutput.play();
+
+        // show send button
+        document.getElementById('uploadButton').style.display = 'inline-block';
+    } catch (error) {
+        console.error('Error processing the file:', error);
+    }
+});
+
+function bufferToWave(abuffer) {
+    const numOfChannels = abuffer.numberOfChannels;
+    const length = abuffer.length * numOfChannels * 2 + 44;
+    const buffer = new ArrayBuffer(length);
+    const view = new DataView(buffer);
+    let offset = 0;
+
+    // Escrever cabeçalho WAV
+    setString(view, offset, 'RIFF'); offset += 4;
+    view.setUint32(offset, length - 8, true); offset += 4;
+    setString(view, offset, 'WAVE'); offset += 4;
+    setString(view, offset, 'fmt '); offset += 4;
+    view.setUint32(offset, 16, true); offset += 4; // format size
+    view.setUint16(offset, 1, true); offset += 2; // PCM format
+    view.setUint16(offset, numOfChannels, true); offset += 2; // number of channels
+    view.setUint32(offset, 8000, true); offset += 4; // sample rate
+    view.setUint32(offset, 8000 * numOfChannels * 2, true); offset += 4; // byte rate
+    view.setUint16(offset, numOfChannels * 2, true); offset += 2; // block align
+    view.setUint16(offset, 16, true); offset += 2; // bits per sample
+
+    setString(view, offset, 'data'); offset += 4;
+    view.setUint32(offset, length - offset - 4, true); offset += 4;
+
+    // Copiar os dados de áudio
+    for (let channel = 0; channel < numOfChannels; channel++) {
+        const channelData = abuffer.getChannelData(channel);
+        for (let i = 0; i < channelData.length; i++) {
+            view.setInt16(offset, channelData[i] * 0x7FFF, true);
+            offset += 2;
+        }
+    }
+
+    return new Blob([buffer], { type: 'audio/wav' });
+}
+
+function setString(view, offset, string) {
+    for (let i = 0; i < string.length; i++) {
+        view.setUint8(offset + i, string.charCodeAt(i));
+    }
+}
+
+document.getElementById('uploadButton').addEventListener('click', async () => {
+    if (!processedAudioBlob) {
+        alert('No processed audio to send.');
+        return;
+    }
+
+    await uploadAudio(processedAudioBlob);
+});
+
+async function uploadAudio(blob) {
+    const formData = new FormData();
+    formData.append('sound', blob, 'processed.wav');
+
+    try {
+        const dominio = window.location.hostname;
+        const response = await fetch(dominio + '/api-sdk/play_sound', {
+            method: 'POST',
+            body: formData,
+        });
+
+        if (!response.ok) {
+            throw new Error('Erro to send audio: ' + response.statusText);
+        }
+
+        const result = await response.json();
+        console.log('Audio sent successfully:', result);
+    } catch (error) {
+        console.error('Error sending audio:', error);
+    }
+}

--- a/chipper/webroot/js/play_audio.js
+++ b/chipper/webroot/js/play_audio.js
@@ -108,7 +108,8 @@ async function uploadAudio(blob) {
 
     try {
         const dominio = window.location.hostname;
-        const response = await fetch(dominio + '/api-sdk/play_sound', {
+        esn = urlParams.get("serial");
+        const response = await fetch('/api-sdk/play_sound?serial='+esn, {
             method: 'POST',
             body: formData,
         });

--- a/chipper/webroot/sdkapp/control.html
+++ b/chipper/webroot/sdkapp/control.html
@@ -86,7 +86,6 @@
           <input class="tinput" name="textSay" id="textSay" type="text" placeholder="Put text here" disabled />
         </div>
         <button onclick="sayText()" type="submit">Submit</button>
-      </div>
       <hr />
       <h2 class="center">Play Audio</h2>
         <div class="center">
@@ -98,6 +97,7 @@
         </div>
       </div>
       <hr />
+    </div>
     </div>
   </div>
   <hr>

--- a/chipper/webroot/sdkapp/control.html
+++ b/chipper/webroot/sdkapp/control.html
@@ -88,6 +88,17 @@
         <button onclick="sayText()" type="submit">Submit</button>
       </div>
       <hr />
+      <h2 class="center">Play Audio</h2>
+        <div class="center">
+          <input type="file" id="fileInput" accept=".wav">
+        </div>
+        <button id="uploadButton" style="display: none;" type="submit">Send Audio</button>
+        <div div class="center">
+          <audio id="audioOutput" controls></audio>
+        </div>
+        
+      </div>
+      <hr />
     </div>
   </div>
   <hr>
@@ -98,6 +109,8 @@
   <script src="./js/iro.min.js"></script>
   <script src="./js/control.js"></script>
   <script src="../js/ui.js"></script>
+  <script src="../js/play_audio.js"></script>
+
   <iframe name="hiddenFrame" width="0" height="0" border="0" style="display: none"></iframe>
 </body>
 

--- a/chipper/webroot/sdkapp/control.html
+++ b/chipper/webroot/sdkapp/control.html
@@ -96,7 +96,6 @@
         <div div class="center">
           <audio id="audioOutput" controls></audio>
         </div>
-        
       </div>
       <hr />
     </div>


### PR DESCRIPTION
Finalmente, terminei. Agora podemos enviar áudio (WAV) para tocar no Vector.

O arquivo play_audio.js pega áudios WAV e os ajusta para 8000 Hz antes de enviá-los para serve.go.

Os áudios WAV são ajustados no lado do cliente, então acredito que o processamento do lado do servidor não será muito pesado.

![image](https://github.com/user-attachments/assets/88683375-fda9-4498-b55c-4a30294b9ee5)
