### PR TITLE
style: revamp navigation items with modern interactions and interactive hover effects and improve navigation experience

### DIFF
--- a/chipper/webroot/css/style.css
+++ b/chipper/webroot/css/style.css
@@ -1,18 +1,18 @@
 @import url("wing.css");
 
-@font-face{ 
+@font-face{
   font-family: 'DroidSans';
   src: url('DroidSans.woff') format('woff');
   /*font license Apache V2.00: https://www.fontsquirrel.com/license/droid-sans*/
 }
 
-@font-face{ 
+@font-face{
   font-family: 'IBMVGA';
   src: url('PxPlus_IBM_VGA_8x16.ttf') format('truetype');
   /* VileR's old school font pack - int10h.org */
 }
 
-@font-face{ 
+@font-face{
   font-family: 'H1Weird';
   src: url('h1Font.ttf') format('truetype');
 }
@@ -39,23 +39,37 @@
 :root {
   --bg-color: #1e1e1e;
   --body-font-family: 'DroidSans', sans-serif;
-  --bg-color-alt: rgba(196,196,196,1);		/* light gray #C4C4C4*/
-  --button-color: rgba(75,75,75,1);		/* dark gray #4B4B4B */
-  --button-color-alt: rgba(164,164,164,1);	/* light gray #A4A4A4 */
-  --fg-color: #00ff80;	        /* light green 33ED6D */
-  --medium-battery: #ced100;		/* bright yellow */
-  --low-battery: #ff0000;		/* bright red */
-  --fg-color-alt: rgba(51,237,109,.05);		/* light green 33ED6D */
-  --text-color: rgba(255,255,255,1);		/* white #FFFFFF */
-  --text-color-alt: rgba(34,34,34,1);		/* black #000000 */
+  --bg-color-alt: rgba(196,196,196,1);        /* light gray #C4C4C4*/
+  --button-color: rgba(75,75,75,1);        /* dark gray #4B4B4B */
+  --button-color-alt: rgba(164,164,164,1);    /* light gray #A4A4A4 */
+  --fg-color: #00ff80;            /* light green 33ED6D */
+  --medium-battery: #ced100;        /* bright yellow */
+  --low-battery: #ff0000;        /* bright red */
+  --fg-color-alt: rgba(51,237,109,.05);        /* light green 33ED6D */
+  --text-color: rgba(255,255,255,1);        /* white #FFFFFF */
+  --text-color-alt: rgba(34,34,34,1);        /* black #000000 */
 }
 
+/* Modified icon styles */
 .selectedicon {
   color: var(--fg-color);
 }
 
 .notselectedicon {
-  color: var(--bg-color-alt);
+  color: var(--fg-color);
+  filter: drop-shadow(0 0 8px var(--fg-color));
+}
+
+.notselectedicon:hover {
+  color: var(--text-color); /* White for hover */
+}
+
+.main-nav-child:hover .selectedicon {
+  color: var(--fg-color);
+}
+
+.selectedicon, .notselectedicon {
+  transition: all 0s ease-in-out;
 }
 
 .dropdown {
@@ -105,15 +119,15 @@ input[type="text"], input[type="file"], select {
   font-size: 1.0em;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
   text-align: center;
-  border: 2px solid var(--fg-color); 
+  border: 2px solid var(--fg-color);
   box-sizing: border-box;
   transition: border-color 0.3s;
 }
 
 input[type="text"]:hover, input[type="file"]:hover, select:hover,
 input[type="text"]:focus, input[type="file"]:focus, select:focus {
-  border-color: white; 
-  border: 2px solid; 
+  border-color: white;
+  border: 2px solid;
   box-sizing: border-box;
   transition: border-color 0.3s;
 }
@@ -186,14 +200,14 @@ textarea {
   font-family: var(--body-font-family);
   font-size: 0.9em;
   height: 280px;
-  border: 2px solid var(--fg-color); 
+  border: 2px solid var(--fg-color);
   box-sizing: border-box;
   transition: border-color 0.3s;
 }
 
 textarea:hover, textarea:focus {
-  border-color: white; 
-  border: 2px solid; 
+  border-color: white;
+  border: 2px solid;
   box-sizing: border-box;
   transition: border-color 0.3s;
 }
@@ -223,7 +237,7 @@ a:hover {
   text-decoration: none;
   color: var(--fg-color);
 }
-/* 
+/*
 ul {
   list-style-type:none;
 } */
@@ -449,22 +463,50 @@ input[type='radio']:disabled:after {
 .main-nav-parent {
   display: flex;
   justify-content: center;
-  flex-wrap: wrap;
+  /* flex-wrap: wrap; */
   /*border: 1px solid black;*/
+  gap: 20px;
   margin: 1rem;
   padding: 1rem 2rem;
   text-align: center;
 }
 
 .main-nav-child {
-  display: inline-block;
-  /*border: 1px solid white;*/
-  padding: 1.2rem 2rem 1.4rem 0rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  border-radius: 12px;
+  border: 1px solid white;
+  padding: 8px 12px;
   vertical-align: top;
+  width: auto;
+  background: rgba(30, 30, 30, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  min-width: 85px;
+  transition: all 0.3s ease-in-out;
   width: 85px;
 }
 
+.main-nav-child:has(.selectedicon) {
+  background: rgba(25, 25, 25, 0.9);
+  border: 1px solid var(--fg-color);
+  box-shadow: 0 0 15px rgba(0, 255, 128, 0.1);
+}
+
+.main-nav-child:hover {
+  transform: translateY(-2px);
+  border-color: white;
+  box-shadow: 0 0 15px rgba(255, 255, 255, 0.1)
+}
+
+.main-nav-child i {
+  font-size: 32px;
+  margin-bottom: 8px;
+  transition: all 0.3s ease-in-out;
+}
+
 .main-nav-child a {
+  width: 100%;
   text-decoration: none;
   font-size: 100%;
   color: var(--bg-color-alt);
@@ -483,7 +525,10 @@ input[type='radio']:disabled:after {
 }
 
 .main-nav-child a img {
-  width:50%;
+  width: 40px;
+  height: 40px;
+  margin-bottom: 8px;
+  object-fit: contain;
 }
 
 input[type='checkbox'] {
@@ -496,7 +541,7 @@ input[type='checkbox'] {
   cursor: pointer;
   position: relative;
   display: inline-block;
-  vertical-align: middle; 
+  vertical-align: middle;
 }
 
 input[type='checkbox']:checked {

--- a/chipper/webroot/css/style.css
+++ b/chipper/webroot/css/style.css
@@ -168,6 +168,7 @@ body {
   margin: 0;
   flex-wrap: wrap;
   text-align: center;
+  padding-top: env(safe-area-inset-top);
 }
 
 
@@ -463,12 +464,13 @@ input[type='radio']:disabled:after {
 .main-nav-parent {
   display: flex;
   justify-content: center;
-  /* flex-wrap: wrap; */
-  /*border: 1px solid black;*/
+  flex-wrap: wrap;
   gap: 20px;
-  margin: 1rem;
-  padding: 1rem 2rem;
+  margin: 1rem auto;
+  padding: 1rem;
   text-align: center;
+  width: 100%;
+  max-width: 950px;
 }
 
 .main-nav-child {
@@ -529,6 +531,32 @@ input[type='radio']:disabled:after {
   height: 40px;
   margin-bottom: 8px;
   object-fit: contain;
+}
+
+/* no horizontal scroll on mobile, grid instead of line*/
+
+@media screen and (max-width: 768px) {
+  .main-nav-parent {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+    gap: 15px;
+    padding: 0.5rem;
+    margin: 0;
+    width: 100%;
+  }
+  
+  #outer {
+    max-width: 100vw;
+    overflow-x: hidden;
+    box-sizing: border-box;
+  }
+
+  #content {
+    width: 100% !important;
+    max-width: 100vw;
+    padding: 0 10px;
+    box-sizing: border-box;
+  }
 }
 
 input[type='checkbox'] {

--- a/chipper/webroot/index.html
+++ b/chipper/webroot/index.html
@@ -4,10 +4,8 @@
 <head>
   <title>Wire-Pod</title>
   <!-- Meta Apple tags for a PWA like experience. -->
-  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="default">
-<!--Match wirepod background-->
   <meta name="theme-color" content="#1e1e1e">
   <link rel="stylesheet" type="text/css" href="css/style.css" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />

--- a/chipper/webroot/index.html
+++ b/chipper/webroot/index.html
@@ -3,8 +3,14 @@
 
 <head>
   <title>Wire-Pod</title>
+  <!-- Meta Apple tags for a PWA like experience. -->
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="default">
+<!--Match wirepod background-->
+  <meta name="theme-color" content="#1e1e1e">
   <link rel="stylesheet" type="text/css" href="css/style.css" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <script src="https://kit.fontawesome.com/7508f396ac.js" crossorigin="anonymous"></script>
   <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
   <meta http-equiv="Pragma" content="no-cache">
@@ -63,7 +69,7 @@
         </h2>
         <div class="content" id="content-add">
           <p>
-            For more details, see 
+            For more details, see
             <a href="https://github.com/kercre123/wire-pod/wiki/Custom-Intents" target="_blank">the Custom Intents page of the wiki</a>
           </p>
           <div id="addIntentStatus"></div>

--- a/chipper/webroot/initial.html
+++ b/chipper/webroot/initial.html
@@ -2,7 +2,12 @@
 <html>
 
 <head>
+    
   <title>Wire-Pod Initial Setup</title>
+  <!-- Meta Apple tags for a PWA like experience. -->
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="default">
+  <meta name="theme-color" content="#1e1e1e">
   <link rel="stylesheet" type="text/css" href="css/style.css" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <script src="https://kit.fontawesome.com/7508f396ac.js" crossorigin="anonymous"></script>

--- a/chipper/webroot/sdkapp/control.html
+++ b/chipper/webroot/sdkapp/control.html
@@ -3,6 +3,10 @@
 
 <head>
   <title>Vector Web App</title>
+  <!-- Meta Apple tags for a PWA like experience. -->
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="default">
+  <meta name="theme-color" content="#1e1e1e">
   <link rel="stylesheet" type="text/css" href="../css/style.css" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <script src="https://kit.fontawesome.com/7508f396ac.js" crossorigin="anonymous"></script>

--- a/chipper/webroot/sdkapp/index.html
+++ b/chipper/webroot/sdkapp/index.html
@@ -3,6 +3,10 @@
 
 <head>
   <title>Vector SDK App</title>
+  <!-- Meta Apple tags for a PWA like experience. -->
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="default">
+  <meta name="theme-color" content="#1e1e1e">
   <link rel="stylesheet" type="text/css" href="../css/style.css" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <script src="https://kit.fontawesome.com/7508f396ac.js" crossorigin="anonymous"></script>

--- a/chipper/webroot/sdkapp/settings.html
+++ b/chipper/webroot/sdkapp/settings.html
@@ -3,6 +3,10 @@
 
 <head>
   <title>Vector Web App</title>
+  <!-- Meta Apple tags for a PWA like experience. -->
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="default">
+  <meta name="theme-color" content="#1e1e1e">
   <link rel="stylesheet" type="text/css" href="../css/style.css">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script src="https://kit.fontawesome.com/7508f396ac.js" crossorigin="anonymous"></script>

--- a/chipper/webroot/setup.html
+++ b/chipper/webroot/setup.html
@@ -3,6 +3,10 @@
 
 <head>
   <title>Wire-Pod Setup</title>
+  <!-- Meta Apple tags for a PWA like experience. -->
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="default">
+  <meta name="theme-color" content="#1e1e1e">
   <link rel="stylesheet" type="text/css" href="css/style.css" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <script src="https://kit.fontawesome.com/7508f396ac.js" crossorigin="anonymous"></script>


### PR DESCRIPTION
 Hi! (This is my first pull request so bare with me here)

## Why
The navigation experience was not as smooth and pretty as it could be.

## What I did

- I updated the icon hover effects with a white border, and a smooth hover effect with a upwards animations
- I utilized the icon selected state so when selected, the border has a foreground color
- Added a slight background tint to indicate what items are selected
- Added ease in out animations to the switching of item states
- Added custom css for small devices (adjusted hover effect)
-Modified navigation icon layout to be a grid on mobile, a line on desktop (when enough space, otherwise it's a wrappable grid)
-Added PWA meta tags for iOS devices on index.html , hiding the search bar, and theming the status bar correctly

-Removed horizontal scroll on mobile for a better experience


## Testing Done

- Tested selected item state on reload
- Tested functionality on main navigation page 
- Tested selected item state on navigation links (eg bot settings)
- Testing smooth handling of changing accent colour
-Tested modified navigation layout on different devices
-Tested reactive scaling without reloading
-Tested modified navigation layout on other pages
-Tested mobile layout on add to Home Screen on iOS and iPad. 


_To do:_

- [ ] Handle the PWA website links for bot settings and other pages when added to home screen. 
- [ ] Correct meta tags on other files

**Navigation Hover effect before**:
![before](https://github.com/user-attachments/assets/d4ef9c8a-3d70-469a-ae7f-51d350a671b4)


**Navigation Hover effect after**
![after](https://github.com/user-attachments/assets/19057e26-7be2-4094-b6b1-40c4234f3fc9)

**Add to home screen before**
![image](https://github.com/user-attachments/assets/88344a5b-2897-4a25-8f71-4a15d49fbd27)

**Add to homescreen after**
![image](https://github.com/user-attachments/assets/556778b1-4b17-4f26-8f3f-9d0fa5646da0)







