### PR TITLE
Add ARM64 Support for Docker Image to Enable Raspberry Pi 5 Compatibility

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -81,6 +81,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
 
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker


### PR DESCRIPTION
**Problem:**
The application could not run in a Docker container on my Raspberry Pi 5 because the Docker image was only built for the `amd64` architecture. Since the Raspberry Pi 5 uses an ARM64 processor, it requires a Docker image built for the `linux/arm64` architecture.

**Solution:**
Updated the GitHub Actions workflow (`docker-publish.yml`) to include ARM64 support by specifying both `linux/amd64` and `linux/arm64` platforms in the `platforms` parameter of the `Build and push Docker image` step. This ensures that Docker images are built and published for both architectures.

**Changes Made:**

- Modified the `docker-publish.yml` file:
  - Added `platforms: linux/amd64,linux/arm64` under the `with` section of the `Build and push Docker image` step.

**Testing:**

- Built and ran the updated Docker image on my Raspberry Pi 5.
- Confirmed that the application starts and functions correctly within the Docker container on the ARM64 architecture.

**Notes:**

- No changes were required in the `Dockerfile` since the base image `ubuntu` supports multiple architectures, including ARM64.
- This change does not affect existing `amd64` builds and maintains backward compatibility.

**Conclusion:**
By adding ARM64 support, we expand the compatibility of our application to run on devices like the Raspberry Pi 5, making it accessible to a broader range of users.