### PR TITLE
Added America/Halifax to timezones

### DIFF
--- a/chipper/webroot/sdkapp/settings.html
+++ b/chipper/webroot/sdkapp/settings.html
@@ -342,6 +342,7 @@
             <option value="America/Argentina/Buenos_Aires">America/Argentina/Buenos_Aires</option>
             <option value="America/Santiago">America/Santiago</option>
             <option value="America/Sao_Paulo">America/Sao_Paulo</option>
+            <option value="America/Halifax">America/Halifax</option>
             <option value="America/St_Johns">America/St_Johns</option>
             <option value="GMT">GMT</option>
             <option value="Europe/Lisbon">Europe/Lisbon</option>


### PR DESCRIPTION
Adding America/Halifax to Timezone, as Atlantic time isn't represented by the options.

Atlantic Time is used in the Canadian provinces of Nova Scotia, New Brunswick, and Prince Edward Island, as well as the the US territories Puerto Rico and the US Virgin Islands.