### PR TITLE
Update compose.yaml to remove obsolete version element

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   wire-pod:
     hostname: escapepod


### PR DESCRIPTION
The version property is not used anymore by docker compose. Having it in the file triggers a warning. More info on this can be found [here](https://docs.docker.com/reference/compose-file/version-and-name/)