### PR TITLE
Bugfix/fix french intent + add localization to number for words2num

### DIFF
--- a/chipper/intent-data/fr-FR.json
+++ b/chipper/intent-data/fr-FR.json
@@ -1,218 +1,277 @@
 [
-  {
-    "name" : "intent_names_username_extend",
-    "keyphrases": ["mon nom est", "mon nom est", "je suis", "voici"]
-  },
-  {
-    "name": "intent_weather_extend",
-    "keyphrases": ["quel temps fait-il", "quel temps fera", "prévisions météorologiques", "meteo"]
-  },
-  {
-    "name": "intent_names_ask",
-    "keyphrases": ["quel est mon nom", "comment m'appelle moi", "qui je suis"]
-  },
-  {
-    "name": "intent_imperative_eyecolor",
-    "keyphrases": ["couleur des yeux", "couleur des yeux", "changer la couleur", "yeux"]
-  },
-  {
-    "name": "intent_character_age",
-    "keyphrases": ["quel âge avez-vous", "quel est votre âge", "quel âge avez-vous"]
-  },
-  {
-    "name": "intent_explore_start",
-    "keyphrases": ["allez explorer", "explore", "allez à l'exploration", "fait un tour"]
-  },
-  {
-    "name": "intent_system_charger",
-    "keyphrases": ["rentrer à la maison", "à la maison", "rechargé", "trouver le chargeur", "aller en charge"]
-  },
-  {
-    "name": "intent_system_sleep",
-    "keyphrases": ["va te coucher", "allez a dormir", "allez au lit", "lit", "bonne nuit"]
-  },
-  {
-    "name": "intent_greeting_goodmorning",
-    "keyphrases": ["jour", "matin", "après-midi"]
-  },
-  {
-    "name": "intent_greeting_goodnight",
-    "keyphrases": ["soir", "soirée"]
-  },
-  {
-    "name": "intent_greeting_goodbye",
-    "keyphrases": ["adieu", "au revoir", "à voir"]
-  },
-  {
-    "name": "intent_seasonal_happynewyear",
-    "keyphrases": ["fireworks", "bonne année"]
-  },
-  {
-    "name": "intent_seasonal_happyholidays",
-    "keyphrases": ["noël", "vacance", "joyeuses fêtes"]
-  },
-  {
-    "name": "intent_amazon_signin",
-    "keyphrases": ["entrez alexa", "inscrivez-toi sur alexa", "activez alexa"]
-  },
-  {
-    "name": "intent_amazon_signin",
-    "keyphrases": ["sortez d'alexa", "désactivez alexa"]
-  },
-  {
-    "name": "intent_imperative_forward",
-    "keyphrases": ["avant"]
-  },
-  {
-    "name": "intent_imperative_turnaround",
-    "keyphrases": ["tourne"]
-  },
-  {
-    "name": "intent_imperative_turnleft",
-    "keyphrases": ["turn à gauche", "allez à gauche"]
-  },
-  {
-    "name": "intent_imperative_turnright",
-    "keyphrases": ["tir à droite", "allez à droite"]
-  },
-  {
-    "name": "intent_play_rollcube",
-    "keyphrases": ["jouez avec le cube", "roulez le cube", "déplacez le cube"]
-  },
-  {
-    "name": "intent_play_popawheelie",
-    "keyphrases": ["sifflez"]
-  },
-  {
-    "name": "intent_play_fistbump",
-    "keyphrases": ["donnez-moi cinq", "donnez-moi les cinq"]
-  },
-  {
-    "name": "intent_play_blackjack",
-    "keyphrases": ["vingt-un", "blackjack"]
-  },
-  {
-    "name": "intent_imperative_affirmative",
-    "keyphrases": ["oui", "à droite", "correct", "oui", "vraie"]
-  },
-  {
-    "name": "intent_imperative_negative",
-    "keyphrases": ["non", "pas", "mal", "false"]
-  },
-  {
-    "name": "intent_photo_take_extend",
-    "keyphrases": ["photo", "selfie", "image"]
-  },
-  {
-    "name": "intent_imperative_praise",
-    "keyphrases": ["bon", "gros", "mythique", "fort", "impressionnant"]
-  },
-  {
-    "name": "intent_imperative_abuse",
-    "keyphrases": ["mal", "stupide", "ça ne va pas"]
-  },
-  {
-    "name": "intent_imperative_apologize",
-    "keyphrases": ["je suis désolé", "désolé"]
-  },
-  {
-    "name": "intent_imperative_backup",
-    "keyphrases": ["retournez"]
-  },
-  {
-    "name": "intent_imperative_volumedown",
-    "keyphrases": ["abaisse le volume"]
-  },
-  {
-    "name": "intent_imperative_volumeup",
-    "keyphrases": ["augmente le volume"]
-  },
-  {
-    "name": "intent_imperative_lookatme",
-    "keyphrases": ["regardez-moi"]
-  },
-  {
-    "name": "intent_imperative_volumelevel_extend",
-    "keyphrases": ["volume"]
-  },
-  {
-    "name": "intent_imperative_shutup",
-    "keyphrases": ["tais-toi", "silence", "ferme"]
-  },
-  {
-    "name": "intent_greeting_hello",
-    "keyphrases": ["bonjour", "comment vas-tu", "bonjour", "bonne soirée", "bon après-midi", "hey", "salut"]
-  },
-  {
-    "name": "intent_imperative_come",
-    "keyphrases": ["viens ici", "viens à moi", "ici"]
-  },
-  {
-    "name": "intent_imperative_love",
-    "keyphrases": ["je t'aime", "mon amour"]
-  },
-  {
-    "name": "intent_knowledge_promptquestion",
-    "keyphrases": ["question"]
-  },
-  {
-    "name": "intent_clock_checktimer",
-    "keyphrases": ["vérifiez le chronomètre", "vérifiez la minuterie"]
-  },
-  {
-    "name": "intent_global_stop_extend",
-    "keyphrases": ["arrêtez le minuteur", "arrêtez le chronomètre"]
-  },
-  {
-    "name": "intent_clock_settimer_extend",
-    "keyphrases": ["démarrez le minuteur", "démarrez le chronomètre"]
-  },
-  {
-    "name": "intent_clock_time",
-    "keyphrases": ["quelle est l'heure", "quelle heure est il"]
-  },
-  {
-    "name": "intent_imperative_quiet",
-    "keyphrases": ["assez", "stop", "restez bien", "restez calme"]
-  },
-  {
-    "name": "intent_imperative_dance",
-    "keyphrases": ["danse"]
-  },
-  {
-    "name": "intent_play_pickupcube",
-    "keyphrases": ["collect"]
-  },
-  {
-    "name": "intent_imperative_fetchcube",
-    "keyphrases": ["apportez le cube"]
-  },
-  {
-    "name": "intent_imperative_findcube",
-    "keyphrases": ["trouver le cube", "trouvez votre cube"]
-  },
-  {
-    "name": "intent_play_anytrick",
-    "keyphrases": ["do something cool", "wonom me", "impression me", "inventer quelque chose"]
-  },
-  {
-    "name": "intent_message_recordmessage_extend",
-    "keyphrases": ["enregistrer"]
-  },
-  {
-    "name": "intent_message_playmessage_extend",
-    "keyphrases": ["reproduire le message", "lisez le message"]
-  },
-  {
-    "name": "intent_blackjack_hit",
-    "keyphrases": ["hit"]
-  },
-  {
-    "name": "intent_blackjack_stand",
-    "keyphrases": ["stand"]
-  },
-  {
-    "name": "intent_play_keepaway",
-    "keyphrases": ["restez loin", "loin", "supprimé", "back"]
-  }
+	{
+		"name" : "intent_names_username_extend", 
+		"keyphrases": ["surnom est", "nom de naissance est ", "mes surnoms sont ", "mon surnom est", "mon pseudo", "pseudo", "mon pseudo est", "mon prénom", "mon prénom est", "prénom est" ],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_weather_extend", 
+		"keyphrases" : ["quel temps fait-il", "quel temps fera", "prévisions météorologiques", "meteo", "quel temps fera t'il", "météo", "prévisions météo"],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_names_ask", 
+		"keyphrases" : ["quel est mon nom", "comment je m'appelle", "qui je suis"],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_imperative_eyecolor",
+		"keyphrases" : ["couleur des yeux", "change ta couleur d'yeux", "change la couleur de tes yeux", "couleur des yeux en", "change ta couleur d'yeux en", "change la couleur de tes yeux en", "change de couleur dieu"],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_character_age", 
+		"keyphrases" : ["t'as quel âge", "quel âge as-tu", "quel est ton âge"],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_explore_start", 
+		"keyphrases" : ["va explorer", "explore", "part en exploration", "fait un tour", "pars à l'aventure", "exploration", "en exploration", "aventure"],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_system_charger", 
+		"keyphrases" : ["rentre à la maison", "à la maison", "recharge", "trouve le chargeur", "va te charger", "trouve ton chargeur" ],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_system_sleep",
+		"keyphrases" : ["cette couche", "d'accoucher", "va te coucher", "va dormir", "va au lit", "endort toi", "en dort toi", "en dortoir", "encore toi", "dors" ],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_system_noaudio",
+		"keyphrases" : ["[blank_audio]", "[door opens]", "[sighs]" ],
+		"requiresexact": true
+	},
+	{	
+		"name": "intent_greeting_goodmorning", 
+		"keyphrases" : ["bonjour", "salut", "matin", "morning", "mourning", "mooning", "it bore", "afternoon", "after noon", "after whom", "good morning" ],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_greeting_goodnight", 
+		"keyphrases" : ["nuit","bonne nuit", "good night", "night" ],
+		"requiresexact": false
+	},
+		{	
+		"name": "intent_greeting_goodbye", 
+		"keyphrases" : ["good bye", "good by", "good buy", "goodbye", "au revoir", "adieu", "a voir", "envoi", "paroi" ],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_seasonal_happynewyear",
+		"keyphrases" : ["bonne année", "feu d'artifice", "fireworks", "new year", "happy new", "happy to", "have been", "i now you", "no year", "enee", "i never", "knew her", "hobhouse", "bennie" ],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_seasonal_happyholidays", 
+		"keyphrases" : ["he holds", "christmas", "behold", "holiday", "noël", "vacances", "joyeux noël", "joyeuses fêtes", "joyeuses Pâques" ],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_amazon_signin", 
+		"keyphrases" : ["connecte-toi à alexa", "connecte-toi alexa", "active Alexa", "log toi", "log toi à Alexa", "active avec ça", "steve alexa"],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_amazon_signin", 
+		"keyphrases" : ["déconnecte toi d'alexa", "désactive Alexa", "délog toi", "délog toi d'Alexa", "déconnecte alexa"],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_imperative_forward",
+		"keyphrases" : ["en avant", "avant", "avance", "tout droit"],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_imperative_turnaround", 
+		"keyphrases" : ["tourne", "tourne à cent quatre vingt", "demi-tour", "cent quatre vingt" ],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_imperative_turnleft", 
+		"keyphrases" : ["tourne à gauche", "gauche", "va à gauche" ],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_imperative_turnright", 
+		"keyphrases" : ["tourne à droite", "droite", "va à droite" ],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_play_rollcube",
+		"keyphrases" : ["fais rouler ton cube", "roule tant que", "roule ton cuve", "roule ton cube", "roule cube", "deplace le cube", "deplace cube", "deplace ton cube", "bouge le cube", "bouge cube", "bouge ton cube", "bouge ton cul", "des places ton coeur" ],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_play_popawheelie", 
+		"keyphrases" : ["fais un wheelie", "fais un huit", "fais à lui", "fais un willy", "wheelie", "wheeling", "fais un wheeling", "la ligne", "mailing", "debout", "le poirier", "poirier", "saut en arrière", "saut arrière", "ce arrière", "willy", "oui ligne", "fait une roue arrière", "roue arrière" ],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_play_fistbump", 
+		"keyphrases" : ["fistbump", "high five", "fils veuve", "six de", "check", "tape m'en cinq", "fils de" ],
+		"requiresexact": false
+	},
+		{	
+		"name": "intent_play_blackjack", 
+		"keyphrases" : ["black", "cards", "game", "joue au blackjack", "blackjack", "cartes", "jouons aux cartes", "joue aux cartes", "vingt et un", "vingt un" ],
+		"requiresexact": false
+	},
+		{	
+		"name": "intent_imperative_affirmative",
+		"keyphrases" : ["yes", "oui", "correct", "tout à fait", "oui s'il te plaît", "en effet" ],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_imperative_negative", 
+		"keyphrases" : ["non", "ne fait pas ça", "non merci" ],
+		"requiresexact": true
+	},
+	{	
+		"name": "intent_photo_take_extend", 
+		"keyphrases" : ["photo", "foto", "selfie", "capture", "prend une photo", "prend une photo de moi" ],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_imperative_praise", 
+		"keyphrases" : ["bien", "génial", "fantastique", "impressionnant", "super", "good robot", "gentil", "gentil robot", "bon robot", "ton robot", "bon gros" ],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_imperative_abuse",
+		"keyphrases" : ["méchant", "pas gentil", "horrible", "stupide", "méchant robot" ],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_imperative_apologize", 
+		"keyphrases" : ["désolé", "excuse-moi", "je te prie de m'excuser", "c'est pas grave", "ce n'est pas grave", "laisse tomber", "je suis désolé", "excuse", "pardon", "pardonne-moi" ],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_imperative_backup", 
+		"keyphrases" : ["recule", "en arrière", "marche arrière"],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_imperative_volumedown",
+		"keyphrases" : ["moins fort", "baisse le son", "baisse son", "baisse le volume", "baisse volume" ],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_imperative_volumeup", 
+		"keyphrases" : ["plus fort", "monte le son", "monte son", "monte le volume", "monte volume"],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_imperative_lookatme", 
+		"keyphrases" : ["regarde-moi"],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_imperative_volumelevel_extend",
+		"keyphrases" : ["volume à fond", "fait du bruit", "fais du bruit", "du bruit" ],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_imperative_shutup", 
+		"keyphrases" : ["tais-toi", "silence", "ferme la" ],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_greeting_hello", 
+		"keyphrases" : ["hello", "hey", "salut", "comment vas-tu" ],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_imperative_come", 
+		"keyphrases" : ["viens ici", "viens à moi", "ici", "viens là" ],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_imperative_love",
+		"keyphrases" : ["love you", "dove you", "i love you", "je t'aime", "mon amour" ],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_knowledge_promptquestion", 
+		"keyphrases" : ["question", "weston", "i have a question", "conversation", "lets talk", "let's talk", "discutons", "parlons", "j'ai une question" ],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_clock_checktimer", 
+		"keyphrases" : ["affiche le minuteur", "affiche un minuteur", "vérifie le minuteur", "il reste combien de temps au minuteur", "combien de temps reste t'il au minuteur", "affiche le chronomètre", "affiche un chronomètre", "vérifie le chronomètre", "il reste combien de temps au chronomètre", "combien de temps reste t'il au chronomètre", "affiche le chrono", "vérifie le chrono", "il reste combien de temps au chrono", "combien de temps reste t'il au chrono","il reste combien de temps", "combien de temps reste t'il", "il reste combien de temps"],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_global_stop_extend", 
+		"keyphrases" : ["arrête le minuteur", "arrête le chronomètre", "stoppe le minuteur", "stoppe le chronomètre", "stop le minuteur", "stop le chronomètre"],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_clock_settimer_extend",
+		"keyphrases" : ["minuteur", "chronomètre", "minuteur pour", "chronomètre pour", "met un minuteur", "met un chronomètre",  "met un minuteur pour", "met un chronomètre pour", "démarre un minuteur", "démarre un chronomètre",  "démarre un minuteur pour", "démarre un chronomètre pour" ],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_clock_time", 
+		"keyphrases" : ["quelle heure est-il", "il est quelle heure", "donne moi l'heure", "affiche l'heure"],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_imperative_quiet", 
+		"keyphrases" : ["assez", "stop", "calme-toi", "reste calme" ],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_imperative_dance", 
+		"keyphrases" : ["danse", "écoute", "écoute la musique", "musique" ],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_play_pickupcube",
+		"keyphrases" : ["ramasse", "ramasse ton cu", "ramasse ton cube", "ramasse ton cuve", "soulève ton cu", "soulève ton cube", "soulève ton cuve", "ramasse cu", "ramasse cube", "ramasse cuve", "soulève cu", "soulève cube", "soulève cuve"  ],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_imperative_fetchcube", 
+		"keyphrases" : ["apporte", "rapporte", "apporte ton cu", "apporte ton cube", "apporte ton cuve", "rapporte ton cu", "rapporte ton cube", "rapporte ton cuve", "apporte cu", "apporte cube", "apporte cuve", "rapporte cu", "rapporte cube", "rapporte cuve" ],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_imperative_findcube", 
+		"keyphrases" : ["trouve", "cherche", "trouve ton cu", "trouve ton cube", "trouve ton cuve", "cherche ton cu", "cherche ton cube", "cherche ton cuve", "trouve cu", "trouve cube", "trouve cuve", "cherche cu", "cherche cube", "cherche cuve" ],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_play_anytrick", 
+		"keyphrases" : ["un tour", "fais un tour", "figure", "fais une figure", "un truc", "un truc cool", "fais un truc", "fais un truc cool", "impressionne-moi", "quelque chose de cool", "fais quelque chose", "fais quelque chose de cool"],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_message_recordmessage_extend",
+		"keyphrases" : ["enregistre" ],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_message_playmessage_extend", 
+		"keyphrases" : ["joue message", "joue le message", "lis message", "lis le message" ],
+		"requiresexact": false
+	},
+		{	
+		"name": "intent_blackjack_hit", 
+		"keyphrases" : ["hit", "yes", "oui", "carte", "card"],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_blackjack_stand", 
+		"keyphrases" : ["stand", "stan", "passe", "reste" ],
+		"requiresexact": false
+	},
+	{	
+		"name": "intent_play_keepaway",
+		"keyphrases": ["va-t'en", "éloigne-toi", "reste loin", "dégage", "fou le camp", "loin" ],
+		"requiresexact": false
+	}
 ]

--- a/chipper/pkg/wirepod/localization/localization.go
+++ b/chipper/pkg/wirepod/localization/localization.go
@@ -38,6 +38,40 @@ const STR_NAME_IS = "str_name_is"
 const STR_NAME_IS2 = "str_name_is1"
 const STR_NAME_IS3 = "str_name_is2"
 const STR_FOR = "str_for"
+const STR_ZERO = "str_zero"
+const STR_ONE = "str_one"
+const STR_TWO = "str_two"
+const STR_THREE = "str_three"
+const STR_FOUR = "str_four"
+const STR_FIVE = "str_five"
+const STR_SIX = "str_six"
+const STR_SEVEN = "str_seven"
+const STR_EIGHT = "str_eight"
+const STR_NINE = "str_nine"
+const STR_TEN = "str_ten"
+const STR_ELEVEN = "str_eleven"
+const STR_TWELVE = "str_twelve"
+const STR_THIRTEEN = "str_thirteen"
+const STR_FOURTEEN = "str_fourteen"
+const STR_FIFTEEN = "str_fifteen"
+const STR_SIXTEEN = "str_sixteen"
+const STR_SEVENTEEN = "str_seventeen"
+const STR_EIGHTEEN = "str_eighteen"
+const STR_NINETEEN = "str_nineteen"
+const STR_TWENTY = "str_twenty"
+const STR_THIRTY = "str_thirty"
+const STR_FOURTY = "str_fourty"
+const STR_FIFTY = "str_fifty"
+const STR_SIXTY = "str_sixty"
+const STR_SEVENTY = "str_seventy"
+const STR_EIGHTY = "str_eighty"
+const STR_NINETY = "str_ninety"
+const STR_ONE_HUNDRED = "str_one_hundred"
+const STR_ONE_HOUR = "str_one_hour"
+const STR_ONE_HOUR_ALT = "str_one_hour_alt"
+const STR_HOUR = "str_hour"
+const STR_MINUTE = "str_minute"
+const STR_SECOND = "str_second"
 
 // for grammer
 var ALL_STR []string = []string{
@@ -75,6 +109,40 @@ var ALL_STR []string = []string{
 	"str_name_is1",
 	"str_name_is2",
 	"str_for",
+	"str_zero",
+	"str_one",
+	"str_two",
+	"str_three",
+	"str_four",
+	"str_five",
+	"str_six",
+	"str_seven",
+	"str_eight",
+	"str_nine",
+	"str_ten",
+	"str_eleven",
+	"str_twelve",
+	"str_thirteen",
+	"str_fourteen",
+	"str_fifteen",
+	"str_sixteen",
+	"str_seventeen",
+	"str_eighteen",
+	"str_nineteen",
+	"str_twenty",
+	"str_thirty",
+	"str_fourty",
+	"str_fifty",
+	"str_sixty",
+	"str_seventy",
+	"str_eighty",
+	"str_ninety",
+	"str_one_hundred",
+	"str_one_hour",
+	"str_one_hour_alt",
+	"str_hour",
+	"str_minute",
+	"str_second",
 }
 
 // All text must be lowercase!
@@ -92,21 +160,21 @@ var texts = map[string][]string{
 	STR_EYE_COLOR_SAPPHIRE:             {"sapphire", "zaffiro", "zafiro", "saphir", "saphir", "szafir", "天蓝", "safir", "синий", "saffier", "синій", "màu ngọc bích"},
 	STR_EYE_COLOR_YELLOW:               {"yellow", "giallo", "amarillo", "jaune", "gelb", "żółty", "黄色", "sarı", "жёлтый", "geel", "жовтий", "màu vàng"},
 	STR_EYE_COLOR_TEAL:                 {"teal", "verde acqua", "verde azulado", "sarcelle", "blaugrün", "morski", "浅绿", "teal", "бирюзовый", "wintertaling", "бірюзовий", "xanh lá cây"},
-	STR_EYE_COLOR_TEAL2:                {"tell", "acquamarina", "aguamarina", "acquamarina", "acquamarina", "akwamaryn", "蓝绿", "turkuaz", "аквамарин", "vertellen", "аквамариновий", "màu xanh ngọc"},
+	STR_EYE_COLOR_TEAL2:                {"tell", "acquamarina", "aguamarina", "acquamarine", "acquamarina", "akwamaryn", "蓝绿", "turkuaz", "аквамарин", "vertellen", "аквамариновий", "màu xanh ngọc"},
 	STR_EYE_COLOR_GREEN:                {"green", "verde", "verde", "vert", "grün", "zielony", "绿色", "yeşil", "зелёный", "groente", "зелений", "màu xanh lá"},
 	STR_EYE_COLOR_ORANGE:               {"orange", "arancio", "naranja", "orange", "orange", "pomarańczowy", "橙色", "turuncu", "оранжевый", "oranje", "оранжевий", "màu cam"},
 	STR_ME:                             {"me", "me", "me", "moi", "mir", "mnie", "我", "ben", "меня", "mij", "мене", "tôi"},
 	STR_SELF:                           {"self", "mi", "mía", "moi", "mein", "ja", "自己", "kendim", "себя", "zelf", "себе", "bản thân"},
 	STR_VOLUME_LOW:                     {"low", "basso", "bajo", "bas", "niedrig", "niski", "低", "düşük", "низкий", "laag", "на мінімум", "thấp"},
 	STR_VOLUME_QUIET:                   {"quiet", "poco rumoroso", "tranquilo", "silencieux", "ruhig", "cichy", "安静", "sessiz", "тихо", "rustig", "тихо", "yên tĩnh"},
-	STR_VOLUME_MEDIUM_LOW:              {"medium low", "medio basso", "medio-bajo", "moyen-doux", "mittelschwer", "średnio niski", "中低", "orta düşük", "ниже среднего", "middel laag", "нижче середнього", "vừa thấp"},
+	STR_VOLUME_MEDIUM_LOW:              {"medium low", "medio basso", "medio-bajo", "moyen bas", "mittelschwer", "średnio niski", "中低", "orta düşük", "ниже среднего", "middel laag", "нижче середнього", "vừa thấp"},
 	STR_VOLUME_MEDIUM:                  {"medium", "medio", "medio", "moyen", "mittel", "średni", "中档", "orta", "средний", "medium", "середню", "vừa"},
 	STR_VOLUME_NORMAL:                  {"normal", "normale", "normal", "normal", "normal", "normalny", "正常", "normal", "нормальный", "normaal", "нормальна", "bình thường"},
-	STR_VOLUME_REGULAR:                 {"regular", "regolare", "regular", "régulier", "regulär", "zwyczajny", "标准", "düzenli", "обычный", "normaal", "звичайна", "thông thường"},
+	STR_VOLUME_REGULAR:                 {"regular", "regolare", "regular", "standard", "regulär", "zwyczajny", "标准", "düzenli", "обычный", "normaal", "звичайна", "thông thường"},
 	STR_VOLUME_MEDIUM_HIGH:             {"medium high", "medio alto", "medio-alto", "moyen-élevé", "mittelhoch", "średno wysoki", "中高", "orta yüksek", "выше среднего", "gemiddeld hoog", "вище середнього", "vừa cao"},
 	STR_VOLUME_HIGH:                    {"high", "alto", "alto", "élevé", "hoch", "wysoki", "高档", "yüksek", "высокий", "hoog", "висока", "cao"},
 	STR_VOLUME_LOUD:                    {"loud", "rumoroso", "fuerte", "fort", "laut", "głośny", "高", "gürültülü", "громкий", "luidruchtig", "гучний", "to"},
-	STR_VOLUME_MUTE:                    {"mute", "muto", "mudo", "", "stumm", "wyciszony", "静音", "sessiz", "немой", "stom", "німий", "im lặng"},
+	STR_VOLUME_MUTE:                    {"mute", "muto", "mudo", "muet", "stumm", "wyciszony", "静音", "sessiz", "немой", "stom", "німий", "im lặng"},
 	STR_VOLUME_NOTHING:                 {"nothing", "nessuno", "nada", "rien", "nichts", "nic", "无声", "hiçbir şey", "", "Niets", "нічого", "không có gì"},
 	STR_VOLUME_SILENT:                  {"silent", "silenzioso", "silencio", "silencieux", "still", "cichy", "悄声", "sessiz", "тихий", "stil", "тихий", "yên lặng"},
 	STR_VOLUME_OFF:                     {"off", "spento", "apagado", "éteindre", "aus", "wyłączony", "关闭", "kapalı", "выключить", "uit", "вимкнути", "tắt"},
@@ -115,6 +183,40 @@ var texts = map[string][]string{
 	STR_NAME_IS2:                       {"'s", "sono ", "soy ", "suis ", "bin ", " się ", "的", "'nin", "", "", "", "của"},
 	STR_NAME_IS3:                       {"names", " chiamo ", " llamo ", "appelle ", "werde", "imię", "名字", "adlar", "имена", "namen", "імена", "tên"},
 	STR_FOR:                            {" for ", " per ", " para ", " pour ", " für ", " dla ", "给", " için ", "для", " voor ", " для ", " cho "},
+	STR_ZERO:							{"zero","zero","zero","zéro","zero","zero","zero","zero","zero","zero","zero","zero",},
+	STR_ONE:							{"one","one","one","un","one","one","one","one","one","one","one","one"},
+	STR_TWO:							{"two","two","two","deux","two","two","two","two","two","two","two","two"},
+	STR_THREE:							{"three","three","three","trois","three","three","three","three","three","three","three","three"},
+	STR_FOUR:							{"four","four","four","quatre","four","four","four","four","four","four","four","four"},
+	STR_FIVE:							{"five","five","five","cinq","five","five","five","five","five","five","five","five"},
+	STR_SIX:							{"six","six","six","six","six","six","six","six","six","six","six","six"},
+	STR_SEVEN:							{"seven","seven","seven","sept","seven","seven","seven","seven","seven","seven","seven","seven"},
+	STR_EIGHT:							{"eight","eight","eight","huit","eight","eight","eight","eight","eight","eight","eight","eight"},
+	STR_NINE:							{"nine","nine","nine","neuf","nine","nine","nine","nine","nine","nine","nine","nine"},
+	STR_TEN:							{"ten","ten","ten","dix","ten","ten","ten","ten","ten","ten","ten","ten"},
+	STR_ELEVEN:							{"eleven","eleven","eleven","onze","eleven","eleven","eleven","eleven","eleven","eleven","eleven","eleven"},
+	STR_TWELVE:							{"twelve","twelve","twelve","douze","twelve","twelve","twelve","twelve","twelve","twelve","twelve","twelve"},
+	STR_THIRTEEN:						{"thirteen","thirteen","thirteen","treize","thirteen","thirteen","thirteen","thirteen","thirteen","thirteen","thirteen","thirteen"},
+	STR_FOURTEEN:						{"fourteen","fourteen","fourteen","quatorze","fourteen","fourteen","fourteen","fourteen","fourteen","fourteen","fourteen","fourteen"},
+	STR_FIFTEEN:						{"fifteen","fifteen","fifteen","quinze","fifteen","fifteen","fifteen","fifteen","fifteen","fifteen","fifteen","fifteen"},
+	STR_SIXTEEN:						{"sixteen","sixteen","sixteen","seize","sixteen","sixteen","sixteen","sixteen","sixteen","sixteen","sixteen","sixteen"},
+	STR_SEVENTEEN:						{"seventeen","seventeen","seventeen","dix-sept","seventeen","seventeen","seventeen","seventeen","seventeen","seventeen","seventeen","seventeen"},
+	STR_EIGHTEEN:						{"eighteen","eighteen","eighteen","dix-huit","eighteen","eighteen","eighteen","eighteen","eighteen","eighteen","eighteen","eighteen"},
+	STR_NINETEEN:						{"nineteen","nineteen","nineteen","dix-neuf","nineteen","nineteen","nineteen","nineteen","nineteen","nineteen","nineteen","nineteen"},
+	STR_TWENTY:							{"twenty","twenty","twenty","vingt","twenty","twenty","twenty","twenty","twenty","twenty","twenty","twenty"},
+	STR_THIRTY:							{"thirty","thirty","thirty","trente","thirty","thirty","thirty","thirty","thirty","thirty","thirty","thirty"},
+	STR_FOURTY:							{"fourty","fourty","fourty","quarante","fourty","fourty","fourty","fourty","fourty","fourty","fourty","fourty"},
+	STR_FIFTY:							{"fifty","fifty","fifty","cinquante","fifty","fifty","fifty","fifty","fifty","fifty","fifty","fifty"},
+	STR_SIXTY:							{"sixty","sixty","sixty","soixante","sixty","sixty","sixty","sixty","sixty","sixty","sixty","sixty"},
+	STR_SEVENTY:						{"seventy","seventy","seventy","soixante-dix","seventy","seventy","seventy","seventy","seventy","seventy","seventy","seventy"},
+	STR_EIGHTY:							{"eighty","eighty","eighty","quatre-vingt","eighty","eighty","eighty","eighty","eighty","eighty","eighty","eighty"},
+	STR_NINETY:							{"ninety","ninety","ninety","quatre vingt dix","ninety","ninety","ninety","ninety","ninety","ninety","ninety","ninety"},
+	STR_ONE_HUNDRED:					{"one hundred","one hundred","one hundred","cent","one hundred","one hundred","one hundred","one hundred","one hundred","one hundred","one hundred","one hundred"},
+	STR_ONE_HOUR:						{"one hour","one hour","one hour","une heure","one hour","one hour","one hour","one hour","one hour","one hour","one hour","one hour"},
+	STR_ONE_HOUR_ALT:					{"an hour","an hour","an hour","une heure","an hour","an hour","an hour","an hour","an hour","an hour","an hour","an hour"},
+	STR_HOUR:							{"hour","hour","hour","heure","hour","hour","hour","hour","hour","hour","hour","hour"},
+	STR_MINUTE:							{"minute","minute","minute","minute","minute","minute","minute","minute","minute","minute","minute","minute"},
+	STR_SECOND:							{"second","second","second","seconde","second","second","second","second","second","second","second","second"},
 }
 
 func GetText(key string) string {

--- a/chipper/pkg/wirepod/ttr/words2num.go
+++ b/chipper/pkg/wirepod/ttr/words2num.go
@@ -1,10 +1,13 @@
 package wirepod_ttr
 
 import (
+	"fmt"
 	"os"
 	"regexp"
 	"strconv"
 	"strings"
+
+	lcztn "github.com/kercre123/wire-pod/chipper/pkg/wirepod/localization" 
 )
 
 // This file contains words2num. It is given the spoken text and returns a string which contains the true number.
@@ -36,15 +39,44 @@ func whisperSpeechtoNum(input string) string {
 	return strconv.Itoa(totalSeconds)
 }
 
+//initialize by default in english during chipper compilation
 var textToNumber = map[string]int{
-	"zero": 0, "one": 1, "two": 2, "three": 3, "four": 4, "five": 5,
-	"six": 6, "seven": 7, "eight": 8, "nine": 9, "ten": 10,
-	"eleven": 11, "twelve": 12, "thirteen": 13, "fourteen": 14, "fifteen": 15,
-	"sixteen": 16, "seventeen": 17, "eighteen": 18, "nineteen": 19, "twenty": 20,
-	"thirty": 30, "forty": 40, "fifty": 50, "sixty": 60,
+	lcztn.GetText(lcztn.STR_ZERO)		: 0, 
+	lcztn.GetText(lcztn.STR_ONE)		: 1, 
+	lcztn.GetText(lcztn.STR_TWO)		: 2, 
+	lcztn.GetText(lcztn.STR_THREE)		: 3, 
+	lcztn.GetText(lcztn.STR_FOUR)		: 4, 
+	lcztn.GetText(lcztn.STR_FIVE)		: 5,
+	lcztn.GetText(lcztn.STR_SIX)		: 6, 
+	lcztn.GetText(lcztn.STR_SEVEN)		: 7, 
+	lcztn.GetText(lcztn.STR_EIGHT)		: 8, 
+	lcztn.GetText(lcztn.STR_NINE)		: 9, 
+	lcztn.GetText(lcztn.STR_TEN)		: 10,
+	lcztn.GetText(lcztn.STR_ELEVEN)		: 11, 
+	lcztn.GetText(lcztn.STR_TWELVE)		: 12, 
+	lcztn.GetText(lcztn.STR_THIRTEEN)	: 13, 
+	lcztn.GetText(lcztn.STR_FOURTEEN)	: 14, 
+	lcztn.GetText(lcztn.STR_FIFTEEN)	: 15,
+	lcztn.GetText(lcztn.STR_SIXTEEN)	: 16, 
+	lcztn.GetText(lcztn.STR_SEVENTEEN)	: 17, 
+	lcztn.GetText(lcztn.STR_EIGHTEEN)	: 18, 
+	lcztn.GetText(lcztn.STR_NINETEEN)	: 19, 
+	lcztn.GetText(lcztn.STR_TWENTY)		: 20,
+	lcztn.GetText(lcztn.STR_THIRTY)		: 30, 
+	lcztn.GetText(lcztn.STR_FOURTY)		: 40, 
+	lcztn.GetText(lcztn.STR_FIFTY)		: 50, 
+	lcztn.GetText(lcztn.STR_SIXTY)		: 60,
+	lcztn.GetText(lcztn.STR_SEVENTY)	: 70,
+	lcztn.GetText(lcztn.STR_EIGHTY)		: 80,
+	lcztn.GetText(lcztn.STR_NINETY)		: 90,
+	lcztn.GetText(lcztn.STR_ONE_HUNDRED): 100,
+
 }
 
 func words2num(input string) string {
+
+	initializeTextToNumberwithCurrentLocalization()
+
 	containsNum, _ := regexp.MatchString(`\b\d+\b`, input)
 	if os.Getenv("STT_SERVICE") == "whisper.cpp" && containsNum {
 		return whisperSpeechtoNum(input)
@@ -52,11 +84,14 @@ func words2num(input string) string {
 	totalSeconds := 0
 
 	input = strings.ToLower(input)
-	if strings.Contains(input, "one hour") || strings.Contains(input, "an hour") {
+	if strings.Contains(input, lcztn.GetText(lcztn.STR_ONE_HOUR)) || strings.Contains(input, lcztn.GetText(lcztn.STR_ONE_HOUR_ALT)) {
 		return "3600"
 	}
 
-	timePattern := regexp.MustCompile(`(\d+|\w+(?:-\w+)?)\s*(minute|second|hour)s?`)
+	str_regex_time_pattern := `(\d+|\w+(?:-\w+)?)\s*(`+lcztn.GetText(lcztn.STR_MINUTE)+`|`+lcztn.GetText(lcztn.STR_SECOND)+`|`+lcztn.GetText(lcztn.STR_HOUR)+`)s?`
+
+	// timePattern := regexp.MustCompile(`(\d+|\w+(?:-\w+)?)\s*(minute|second|hour)s?`)
+	timePattern := regexp.MustCompile(str_regex_time_pattern)
 
 	matches := timePattern.FindAllStringSubmatch(input, -1)
 	for _, match := range matches {
@@ -69,11 +104,14 @@ func words2num(input string) string {
 		}
 
 		switch unit {
-		case "minute":
+		// minute	
+		case lcztn.GetText(lcztn.STR_MINUTE):
 			totalSeconds += value * 60
-		case "second":
+		// second	
+		case lcztn.GetText(lcztn.STR_SECOND):
 			totalSeconds += value
-		case "hour":
+		// hour	
+		case lcztn.GetText(lcztn.STR_HOUR):
 			totalSeconds += value * 3600
 		}
 	}
@@ -93,4 +131,40 @@ func mapTextToNumber(text string) int {
 		}
 	}
 	return sum
+
+}
+
+func initializeTextToNumberwithCurrentLocalization () {
+	textToNumber = map[string]int{
+		lcztn.GetText(lcztn.STR_ZERO)		: 0, 
+		lcztn.GetText(lcztn.STR_ONE)		: 1, 
+		lcztn.GetText(lcztn.STR_TWO)		: 2, 
+		lcztn.GetText(lcztn.STR_THREE)		: 3, 
+		lcztn.GetText(lcztn.STR_FOUR)		: 4, 
+		lcztn.GetText(lcztn.STR_FIVE)		: 5,
+		lcztn.GetText(lcztn.STR_SIX)		: 6, 
+		lcztn.GetText(lcztn.STR_SEVEN)		: 7, 
+		lcztn.GetText(lcztn.STR_EIGHT)		: 8, 
+		lcztn.GetText(lcztn.STR_NINE)		: 9, 
+		lcztn.GetText(lcztn.STR_TEN)		: 10,
+		lcztn.GetText(lcztn.STR_ELEVEN)		: 11, 
+		lcztn.GetText(lcztn.STR_TWELVE)		: 12, 
+		lcztn.GetText(lcztn.STR_THIRTEEN)	: 13, 
+		lcztn.GetText(lcztn.STR_FOURTEEN)	: 14, 
+		lcztn.GetText(lcztn.STR_FIFTEEN)	: 15,
+		lcztn.GetText(lcztn.STR_SIXTEEN)	: 16, 
+		lcztn.GetText(lcztn.STR_SEVENTEEN)	: 17, 
+		lcztn.GetText(lcztn.STR_EIGHTEEN)	: 18, 
+		lcztn.GetText(lcztn.STR_NINETEEN)	: 19, 
+		lcztn.GetText(lcztn.STR_TWENTY)		: 20,
+		lcztn.GetText(lcztn.STR_THIRTY)		: 30, 
+		lcztn.GetText(lcztn.STR_FOURTY)		: 40, 
+		lcztn.GetText(lcztn.STR_FIFTY)		: 50, 
+		lcztn.GetText(lcztn.STR_SIXTY)		: 60,
+		lcztn.GetText(lcztn.STR_SEVENTY)	: 70,
+		lcztn.GetText(lcztn.STR_EIGHTY)		: 80,
+		lcztn.GetText(lcztn.STR_NINETY)		: 90,
+		lcztn.GetText(lcztn.STR_ONE_HUNDRED): 100,
+	
+	}
 }


### PR DESCRIPTION
This PR is about to edit french intent to be more accurate for french people pronounciation.
It also provide the ability to customize the prounouciation of number and link it to the localization. I noticed that when using french to talk to vector, the timer intent accepted french but not when using number. I had to prounouce them in english.
So I added some changes so that people can customize them in their own langage if need. Default is english for the moment to avoid breaking all.