### PR TITLE
Custom host for Whisper STT

### DIFF
--- a/chipper/pkg/wirepod/speechrequest/speechrequest.go
+++ b/chipper/pkg/wirepod/speechrequest/speechrequest.go
@@ -108,7 +108,7 @@ func BytesToIntVAD(stream opus.OggStream, data []byte, die bool, isOpus bool) []
 // Uses VAD to detect when the user stops speaking
 func (req *SpeechRequest) DetectEndOfSpeech() (bool, bool) {
 	// changes InactiveFrames and ActiveFrames in req
-	inactiveNumMax := 100
+	inactiveNumMax := 23
 	for _, chunk := range SplitVAD(req.LastAudioChunk) {
 		active, err := req.VADInst.Process(16000, chunk)
 		if err != nil {

--- a/chipper/pkg/wirepod/speechrequest/speechrequest.go
+++ b/chipper/pkg/wirepod/speechrequest/speechrequest.go
@@ -108,7 +108,7 @@ func BytesToIntVAD(stream opus.OggStream, data []byte, die bool, isOpus bool) []
 // Uses VAD to detect when the user stops speaking
 func (req *SpeechRequest) DetectEndOfSpeech() (bool, bool) {
 	// changes InactiveFrames and ActiveFrames in req
-	inactiveNumMax := 23
+	inactiveNumMax := 100
 	for _, chunk := range SplitVAD(req.LastAudioChunk) {
 		active, err := req.VADInst.Process(16000, chunk)
 		if err != nil {

--- a/chipper/pkg/wirepod/stt/whisper/Whisper.go
+++ b/chipper/pkg/wirepod/stt/whisper/Whisper.go
@@ -24,8 +24,8 @@ type openAiResp struct {
 }
 
 func Init() error {
-	if os.Getenv("OPENAI_KEY") == "" {
-		logger.Println("This is an early implementation of the Whisper API which has not been implemented into the web interface. You must set the OPENAI_KEY env var.")
+	if os.Getenv("OPENAI_KEY") == "" && os.Getenv("STT_HOST") == "" {
+		logger.Println("This is an early implementation of the Whisper API which has not been implemented into the web interface. You must set the OPENAI_KEY env var, OR set STT_HOST to point to a custom server.")
 		//os.Exit(1)
 	}
 	return nil
@@ -77,18 +77,43 @@ func newAudioIntBuffer(r io.Reader) (*audio.IntBuffer, error) {
 }
 
 func makeOpenAIReq(in []byte) string {
-	url := "https://api.openai.com/v1/audio/transcriptions"
+	// Check for custom host
+	host := os.Getenv("STT_HOST")
+	var url string
+	if host != "" {
+		// Use custom host. Assume it's the full base URL or handle appending.
+		// Let's assume STT_HOST is the FULL URL (e.g. http://1.2.3.4:8001/v1/audio/transcriptions)
+		if !strings.HasPrefix(host, "http") {
+			host = "http://" + host
+		}
+		url = host
+		// If it looks like just a base (no 'audio/transcriptions'), append it?
+		if !strings.Contains(url, "/transcriptions") {
+			if strings.HasSuffix(url, "/") {
+				url += "v1/audio/transcriptions"
+			} else {
+				url += "/v1/audio/transcriptions"
+			}
+		}
+	} else {
+		url = "https://api.openai.com/v1/audio/transcriptions"
+	}
 
 	buf := new(bytes.Buffer)
 	w := multipart.NewWriter(buf)
 	w.WriteField("model", "whisper-1")
-	sendFile, _ := w.CreateFormFile("file", "audio.mp3")
+	sendFile, _ := w.CreateFormFile("file", "audio.wav")
 	sendFile.Write(in)
 	w.Close()
 
 	httpReq, _ := http.NewRequest("POST", url, buf)
 	httpReq.Header.Set("Content-Type", w.FormDataContentType())
-	httpReq.Header.Set("Authorization", "Bearer "+os.Getenv("OPENAI_KEY"))
+	// Use dummy key if not set, or forwarded key
+	key := os.Getenv("OPENAI_KEY")
+	if key == "" {
+		key = "dummy"
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+key)
 
 	client := &http.Client{}
 	resp, err := client.Do(httpReq)
@@ -104,6 +129,11 @@ func makeOpenAIReq(in []byte) string {
 	var aiResponse openAiResp
 	json.Unmarshal(response, &aiResponse)
 
+	// Fallback/Debugging
+	if aiResponse.Text == "" {
+		logger.Println("Whisper response empty. Raw response: " + string(response))
+	}
+
 	return aiResponse.Text
 }
 
@@ -114,8 +144,11 @@ func STT(req sr.SpeechRequest) (string, error) {
 	for {
 		_, err = req.GetNextStreamChunk()
 		if err != nil {
+			if err == io.EOF {
+				break
+			}
 			return "", err
-		}
+		} // Why double ?
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
Hello,
I did a tiny change on Wire-pod to support custom Whisper endpoints. 

Why ? :
- My Pi is too weak for anything else
- I don't have an OpenAI subscription
- I'm already running a 24/7 Whisper server on another machine

I had to change the STT silence period to 1 second as it feels much nicer to me, it used to cut on my while I was talking. 😂

2 changes that I'm asking for help with : 
- Why is there 2 error checks at same place doing the same thing? I modified the last one to catch EOF which happens if the Whisper request is super long like >10 seconds.
- I don't see any conversion to mp3 anywhere and on my local server, WAV just worked and is direct. Is it just sending a PCM to WAV renamed as MP3 ?

Thanks! :)