### PR TITLE
Fix timezone for New Zealand

### DIFF
--- a/chipper/webroot/sdkapp/settings.html
+++ b/chipper/webroot/sdkapp/settings.html
@@ -379,7 +379,7 @@
             <option value="Australia/Adelaide">Australia/Adelaide</option>
             <option value="Australia/Brisbane">Australia/Brisbane</option>
             <option value="Australia/Sydney">Australia/Sydney</option>
-            <option value="Australia/Auckland">Australia/Auckland</option>
+            <option value="Pacific/Auckland">Pacific/Auckland</option>
           </select>
         </div>
         <br />


### PR DESCRIPTION
Australia/Auckland does not exist on my Vector, return Pacific/Auckland instead.

Reason : 
- If user set Australia/Auckland -> Vector returns CET time instead.
- in `/usr/share/zoneinfo/` using WireOS at least, Auckland is in `Pacific` folder, not `Australia`

This is normal Linux behaviour IMO as it's where it is on every Linux distribution, but I wonder if it's only for WireOS as I don't have access to an unlocked stock firmware.

Leaving this as a PR if that's actually the case on all firmwares then we're good 🔥
Thanks :)