### PR TITLE
Fix missing volume definition in compose.yaml

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -24,3 +24,5 @@ services:
 volumes:
   wire-pod-data:
     driver: local
+  wire-pod-images:
+    driver: local

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,7 +2,7 @@ services:
   wire-pod:
     container_name: wire-pod
     hostname: escapepod
-    image: ghcr.io/kercre123/wire-pod:main
+    build: .
     restart: unless-stopped
     environment:
       WIREPOD_DATA_DIR: /data


### PR DESCRIPTION
Add the missing volume definition for `wire-pod-images` in the `compose.yaml` file.