### PR TITLE
Add mDNS warning for Android devices in connection setup

### DIFF
--- a/chipper/webroot/initial.html
+++ b/chipper/webroot/initial.html
@@ -41,6 +41,9 @@
               IP Address (recommended for OSKR/dev-unlocked robots)
             </option>
           </select>
+          <div id="androidEpWarning" style="display:none;color:#e67e22;margin-top:8px;">
+            Android cannot resolve <strong>escapepod.local</strong> via mDNS. If you are activating Vector from an Android device or using the wire-pod Android APK, select <strong>IP Address</strong> mode instead.
+          </div>
           <div class="center" id="portViz" style="display: none">
             <label for="portInput">Input custom port here (default is 443)</label>
             <input type="text" id="portInput" name="portInput" placeholder="443" />
@@ -90,6 +93,7 @@
 <!-- <script src="./sdkapp/js/main.js"></script> -->
 <script>
   checkLanguage();
+  checkConn();
 </script>
 
 </html>

--- a/chipper/webroot/js/initial.js
+++ b/chipper/webroot/js/initial.js
@@ -72,9 +72,17 @@ function sendSetupInfo() {
     });
 }
 
+function isMobile() {
+  return /android/i.test(navigator.userAgent);
+}
+
 function checkConn() {
   const connValue = document.getElementById("connSelection").value;
   document.getElementById("portViz").style.display = connValue === "ip" ? "block" : "none";
+  const warn = document.getElementById("androidEpWarning");
+  if (warn) {
+    warn.style.display = (connValue === "ep" && isMobile()) ? "block" : "none";
+  }
 }
 
 function setConn() {


### PR DESCRIPTION
Fixes #501

Android devices can't resolve escapepod.local via mDNS, so users trying to activate Vector from mobile end up stuck. Added a warning that pops up when they select escapepod.local mode on Android, pointing them to use IP address instead.