### PR TITLE
fix: defer robot.Close() in kgsim.go to release per-query gRPC connections

### DIFF
--- a/chipper/pkg/wirepod/ttr/kgsim.go
+++ b/chipper/pkg/wirepod/ttr/kgsim.go
@@ -211,8 +211,15 @@ func StreamingKGSim(req interface{}, esn string, transcribedText string, isKG bo
 		if err != nil {
 			return err.Error(), err
 		}
+		// Release the gRPC connection when this request finishes — otherwise
+		// every voice query leaks a connection and the robot's SDK wedges.
+		defer robot.Close()
 	}
-	_, err := robot.Conn.BatteryState(context.Background(), &vectorpb.BatteryStateRequest{})
+	// 5s timeout: if the robot's SDK is unresponsive this fails fast instead
+	// of hanging forever on context.Background().
+	batCtx, batCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	_, err := robot.Conn.BatteryState(batCtx, &vectorpb.BatteryStateRequest{})
+	batCancel()
 	if err != nil {
 		return "", err
 	}
@@ -532,6 +539,8 @@ func KGSim(esn string, textToSay string) error {
 		},
 	}
 	go func() {
+		// Release the robot connection when this speak-goroutine finishes.
+		defer robot.Close()
 		start := make(chan bool)
 		stop := make(chan bool)
 


### PR DESCRIPTION
Every voice query through `StreamingKGSim()` and the speak goroutine in `KGSim()` opens a fresh `vector.New()` but never releases the underlying gRPC connection. The robot's SDK has a small connection budget; once it fills (3–6 queries on a healthy Vector), the SDK wedges and operators see "Vector having trouble thinking" until wire-pod is bounced.

### Changes (3 hunks, `chipper/pkg/wirepod/ttr/kgsim.go`)

1. `defer robot.Close()` after the per-request `vector.New()` in `StreamingKGSim()`
2. `defer robot.Close()` in the speak goroutine of `KGSim()`
3. 5 s timeout on the opening `BatteryState` probe (was `context.Background()`) — a wedged robot fails fast instead of hanging the whole pipeline

### ⚠️ Depends on a `Close()` method being added to fforchino/vector-go-sdk

The upstream SDK keeps `*grpc.ClientConn` private and never exposes a close path, so this PR won't compile against `vector-go-sdk` `main` as-is. The minimal SDK change is ~19 lines:

```go
// Vector struct gains:
+   grpcConn *grpc.ClientConn

// Add Close() method:
+ func (v *Vector) Close() error {
+     if v == nil || v.grpcConn == nil { return nil }
+     err := v.grpcConn.Close()
+     v.grpcConn = nil
+     return err
+ }

// In New() — store the conn so Close() can release it:
    r := Vector{
-       Conn: vectorpb.NewExternalInterfaceClient(c.Conn()),
-       Cfg:  cfg,
+       Conn:     vectorpb.NewExternalInterfaceClient(c.Conn()),
+       Cfg:      cfg,
+       grpcConn: c.Conn(),
    }
```

**Three options for moving forward:**
1. Companion PR to fforchino/vector-go-sdk with the diff above; once it merges, bump the Go module here and this exits Draft.
2. Vendor `vector-go-sdk` into `chipper/third_party/` with a `replace` directive and apply the same change locally. (This is what my deployment currently does — clean ~7 days uptime on a Pi 4 + Vector 00509655 after applying both together.)
3. Wait for the upstream SDK fix without merging this; leak stays, no new maintenance burden lands here.

Happy to open the SDK companion PR or vendor-it-locally PR if there's appetite for either path — just let me know which.

### Test evidence

- Reproduction (without patch): kercre123/wire-pod `dccc6b9` on a Pi 4. Six voice queries with 2–3 s pauses. By query 4 the robot stops responding; `chipper.log` shows queries reaching kgsim but never returning. `tcpdump -i wlan0 host <vector-ip>` confirms gRPC half-open TCP states stacking up.
- After patch (kgsim.go + vendored SDK Close()): same Pi, same setup, six queries in a row complete with no degradation. `tcpdump` shows each session opened+closed cleanly.

### Provenance

Originally diagnosed and patched by [@Gman0909](https://github.com/Gman0909) in the [VectorIntelligence](https://github.com/Gman0909/VectorIntelligence) single-machine deployment kit (`patches/fix-connection-leak.py` + `patches/add-sdk-close.py`). Ported here unchanged after verifying the anchors apply cleanly to upstream `kercre123/wire-pod`.

Marked Draft until the SDK side has a path forward.