### PR TITLE
Add Groq cloud STT engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@
 /whisper.cpp
 .DS_Store
 /chipper/openaiChats.json
+chipper/source.sh
+chipper/pico.key
+chipper/chipper
+chipper/main

--- a/chipper/cmd/groq/main.go
+++ b/chipper/cmd/groq/main.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"github.com/kercre123/wire-pod/chipper/pkg/initwirepod"
+	stt "github.com/kercre123/wire-pod/chipper/pkg/wirepod/stt/groq"
+)
+
+func main() {
+	initwirepod.StartFromProgramInit(stt.Init, stt.STT, stt.Name)
+}

--- a/chipper/pkg/wirepod/stt/groq/Groq.go
+++ b/chipper/pkg/wirepod/stt/groq/Groq.go
@@ -1,0 +1,317 @@
+package wirepod_groq
+
+// Groq cloud Speech-to-Text engine for wire-pod.
+//
+// This implements the same engine interface as the built-in VOSK/Whisper
+// modules (an exported Name string, an Init() error, and an
+// STT(sr.SpeechRequest) (string, error) function), but instead of running a
+// model locally it streams the captured audio to Groq's OpenAI-compatible
+// transcription endpoint, which runs whisper-large-v3 on Groq's hardware.
+//
+// This is ideal for low-power hosts (e.g. a Raspberry Pi 3B+) that cannot run
+// a large local model: the Pi only captures and forwards audio, while Groq
+// does the recognition. It also handles accented speech and non-English
+// languages (e.g. Greek) far better than the small local VOSK model.
+//
+// Configuration is via environment variables (set these in
+// chipper/source.sh so start.sh picks them up):
+//
+//	GROQ_API_KEY       (required) Your Groq API key.
+//	GROQ_STT_MODEL     (optional) Transcription model.
+//	                              Default: "whisper-large-v3" (most accurate, multilingual).
+//	                              Alternatives: "whisper-large-v3-turbo" (faster, slightly
+//	                              less accurate), "distil-whisper-large-v3-en" (English-only, fastest).
+//	GROQ_STT_LANGUAGE  (optional) ISO-639-1 language code to force, e.g. "en" or "el".
+//	                              Leave unset for automatic language detection (good for
+//	                              switching between English and Greek). Forcing a language
+//	                              improves accuracy/latency on short commands.
+//	GROQ_STT_PROMPT    (optional) A short biasing prompt passed to Whisper. Useful to nudge
+//	                              recognition toward expected vocabulary, e.g.
+//	                              "Hey Vector. Commands: set timer, cancel timer, what time is it".
+//	GROQ_API_URL       (optional) Override the endpoint. Defaults to Groq's transcription URL.
+//	                              You can point this at OpenAI or any OpenAI-compatible
+//	                              transcription endpoint instead.
+//
+// Because Groq's API is OpenAI-compatible, the request shape here matches the
+// standard /audio/transcriptions multipart form.
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/go-audio/audio"
+	"github.com/go-audio/wav"
+	"github.com/kercre123/wire-pod/chipper/pkg/logger"
+	sr "github.com/kercre123/wire-pod/chipper/pkg/wirepod/speechrequest"
+	"github.com/orcaman/writerseeker"
+)
+
+// Name is the value wire-pod uses to identify this engine (STT_SERVICE=groq).
+var Name string = "groq"
+
+const (
+	defaultURL   = "https://api.groq.com/openai/v1/audio/transcriptions"
+	defaultModel = "whisper-large-v3"
+	// httpTimeout bounds a single transcription request. Groq transcribes a
+	// short utterance in well under a second, so this is generous headroom.
+	httpTimeout = 30 * time.Second
+	// maxRetries is how many additional attempts to make on a transient
+	// failure (network error / HTTP 429 / HTTP 5xx). Kept small so the user
+	// isn't left waiting: a voice assistant should fail fast rather than hang.
+	maxRetries = 2
+)
+
+// groqResp models the JSON returned for response_format=json. On success the
+// transcript is in Text; on failure Groq/OpenAI return an Error object.
+type groqResp struct {
+	Text  string `json:"text"`
+	Error *struct {
+		Message string `json:"message"`
+		Type    string `json:"type"`
+		Code    string `json:"code"`
+	} `json:"error"`
+}
+
+func apiURL() string {
+	if v := strings.TrimSpace(os.Getenv("GROQ_API_URL")); v != "" {
+		return v
+	}
+	return defaultURL
+}
+
+func model() string {
+	if v := strings.TrimSpace(os.Getenv("GROQ_STT_MODEL")); v != "" {
+		return v
+	}
+	return defaultModel
+}
+
+// Init validates configuration and logs the active settings. It intentionally
+// does NOT exit on a missing key (mirroring the built-in Whisper module) so
+// that wire-pod can still boot and present its web setup page.
+func Init() error {
+	if strings.TrimSpace(os.Getenv("GROQ_API_KEY")) == "" {
+		logger.Println("[groq-stt] WARNING: GROQ_API_KEY is not set. " +
+			"Set it in chipper/source.sh (export GROQ_API_KEY=\"...\") or transcription will fail.")
+	}
+	lang := strings.TrimSpace(os.Getenv("GROQ_STT_LANGUAGE"))
+	if lang == "" {
+		lang = "auto-detect"
+	}
+	logger.Println(fmt.Sprintf("[groq-stt] initialized (model=%s, language=%s, url=%s)",
+		model(), lang, apiURL()))
+	return nil
+}
+
+// newAudioIntBuffer reads little-endian signed 16-bit PCM from r into an
+// IntBuffer suitable for the WAV encoder.
+func newAudioIntBuffer(r io.Reader) (*audio.IntBuffer, error) {
+	buf := audio.IntBuffer{
+		Format: &audio.Format{
+			NumChannels: 1,
+			SampleRate:  16000,
+		},
+	}
+	for {
+		var sample int16
+		err := binary.Read(r, binary.LittleEndian, &sample)
+		switch {
+		case err == io.EOF:
+			return &buf, nil
+		case err != nil:
+			return nil, err
+		}
+		buf.Data = append(buf.Data, int(sample))
+	}
+}
+
+// pcm2wav wraps raw 16 kHz / 16-bit / mono PCM in a WAV container so the
+// transcription endpoint receives a self-describing audio file.
+func pcm2wav(in io.Reader) ([]byte, error) {
+	out := &writerseeker.WriterSeeker{}
+	// 16 kHz, 16-bit, 1 channel, PCM (WAV audio format 1).
+	enc := wav.NewEncoder(out, 16000, 16, 1, 1)
+
+	audioBuf, err := newAudioIntBuffer(in)
+	if err != nil {
+		return nil, fmt.Errorf("decoding pcm: %w", err)
+	}
+	if err := enc.Write(audioBuf); err != nil {
+		return nil, fmt.Errorf("encoding wav: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("finalizing wav: %w", err)
+	}
+	outBuf := new(bytes.Buffer)
+	if _, err := io.Copy(outBuf, out.BytesReader()); err != nil {
+		return nil, fmt.Errorf("buffering wav: %w", err)
+	}
+	return outBuf.Bytes(), nil
+}
+
+// buildRequest constructs a fresh multipart transcription request. It is built
+// per-attempt because an *http.Request body is not reusable across retries.
+func buildRequest(wavData []byte) (*http.Request, error) {
+	body := new(bytes.Buffer)
+	w := multipart.NewWriter(body)
+
+	if err := w.WriteField("model", model()); err != nil {
+		return nil, err
+	}
+	// response_format=json gives us {"text": "..."} and lets us surface
+	// structured errors.
+	if err := w.WriteField("response_format", "json"); err != nil {
+		return nil, err
+	}
+	// temperature=0 makes recognition deterministic (best for commands).
+	if err := w.WriteField("temperature", "0"); err != nil {
+		return nil, err
+	}
+	if lang := strings.TrimSpace(os.Getenv("GROQ_STT_LANGUAGE")); lang != "" {
+		if err := w.WriteField("language", lang); err != nil {
+			return nil, err
+		}
+	}
+	if prompt := strings.TrimSpace(os.Getenv("GROQ_STT_PROMPT")); prompt != "" {
+		if err := w.WriteField("prompt", prompt); err != nil {
+			return nil, err
+		}
+	}
+
+	// The filename's extension tells the server the container format.
+	part, err := w.CreateFormFile("file", "audio.wav")
+	if err != nil {
+		return nil, err
+	}
+	if _, err := part.Write(wavData); err != nil {
+		return nil, err
+	}
+	if err := w.Close(); err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, apiURL(), body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", w.FormDataContentType())
+	req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(os.Getenv("GROQ_API_KEY")))
+	return req, nil
+}
+
+// transcribe sends the WAV to Groq and returns the recognized text. It retries
+// a small number of times on transient failures (network errors, HTTP 429, and
+// HTTP 5xx) with a short backoff, and fails fast on client errors (e.g. a bad
+// API key) so problems are surfaced immediately in the logs.
+func transcribe(wavData []byte) (string, error) {
+	client := &http.Client{Timeout: httpTimeout}
+	var lastErr error
+
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if attempt > 0 {
+			backoff := time.Duration(attempt) * 500 * time.Millisecond
+			logger.Println(fmt.Sprintf("[groq-stt] retry %d/%d after %s (%v)",
+				attempt, maxRetries, backoff, lastErr))
+			time.Sleep(backoff)
+		}
+
+		req, err := buildRequest(wavData)
+		if err != nil {
+			// Construction errors are not transient; stop.
+			return "", fmt.Errorf("building request: %w", err)
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			lastErr = fmt.Errorf("request failed: %w", err)
+			continue // network error: retry
+		}
+
+		respBody, readErr := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if readErr != nil {
+			lastErr = fmt.Errorf("reading response: %w", readErr)
+			continue
+		}
+
+		// Retry on rate limiting and server errors; fail fast otherwise.
+		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500 {
+			lastErr = fmt.Errorf("server returned HTTP %d: %s",
+				resp.StatusCode, strings.TrimSpace(string(respBody)))
+			continue
+		}
+
+		var parsed groqResp
+		if err := json.Unmarshal(respBody, &parsed); err != nil {
+			// Unparseable body on a non-OK status is still a hard error.
+			if resp.StatusCode != http.StatusOK {
+				return "", fmt.Errorf("HTTP %d and unparseable response: %s",
+					resp.StatusCode, strings.TrimSpace(string(respBody)))
+			}
+			return "", fmt.Errorf("parsing response: %w", err)
+		}
+
+		if parsed.Error != nil {
+			// Structured API error (e.g. invalid key, bad model): do not retry.
+			return "", fmt.Errorf("groq api error: %s", parsed.Error.Message)
+		}
+		if resp.StatusCode != http.StatusOK {
+			return "", fmt.Errorf("HTTP %d: %s",
+				resp.StatusCode, strings.TrimSpace(string(respBody)))
+		}
+
+		return parsed.Text, nil
+	}
+
+	if lastErr == nil {
+		lastErr = errors.New("transcription failed for an unknown reason")
+	}
+	return "", fmt.Errorf("groq transcription failed after %d attempts: %w",
+		maxRetries+1, lastErr)
+}
+
+// STT satisfies the wire-pod engine interface. It drains the bot's audio
+// stream until end-of-speech is detected, packages the captured PCM as WAV,
+// sends it to Groq, and returns the lowercased transcript for intent matching.
+func STT(req sr.SpeechRequest) (string, error) {
+	logger.Println("(Bot " + req.Device + ", Groq) Processing...")
+
+	for {
+		if _, err := req.GetNextStreamChunk(); err != nil {
+			return "", err
+		}
+		done, _ := req.DetectEndOfSpeech()
+		if done {
+			break
+		}
+	}
+
+	pcmBuf := &writerseeker.WriterSeeker{}
+	if _, err := pcmBuf.Write(req.DecodedMicData); err != nil {
+		return "", fmt.Errorf("buffering mic data: %w", err)
+	}
+	wavData, err := pcm2wav(pcmBuf.BytesReader())
+	if err != nil {
+		return "", err
+	}
+
+	text, err := transcribe(wavData)
+	if err != nil {
+		logger.Println("[groq-stt] " + err.Error())
+		return "", err
+	}
+
+	transcribedText := strings.ToLower(strings.TrimSpace(text))
+	transcribedText = strings.TrimRight(transcribedText, ".,!?;:")
+	logger.Println("Bot " + req.Device + " Transcribed text: " + transcribedText)
+	return transcribedText, nil
+}

--- a/chipper/pkg/wirepod/stt/groq/Groq.go
+++ b/chipper/pkg/wirepod/stt/groq/Groq.go
@@ -42,9 +42,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"mime/multipart"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -79,6 +81,40 @@ type groqResp struct {
 		Type    string `json:"type"`
 		Code    string `json:"code"`
 	} `json:"error"`
+}
+
+// defaultSilenceRMSThreshold is the RMS amplitude below which captured audio is
+// treated as silence/noise and NOT sent for transcription. This prevents Whisper
+// from "hallucinating" common phrases (e.g. "thank you", "bye") on near-silent
+// audio, which happens when the wake word triggers but nothing is actually said.
+//
+// Scale: 16-bit samples (-32768..32767). Silence ~0, ambient noise tens,
+// whispering hundreds, normal speech thousands. Tune via GROQ_STT_SILENCE_RMS.
+const defaultSilenceRMSThreshold = 200.0
+
+func silenceThreshold() float64 {
+	if v := strings.TrimSpace(os.Getenv("GROQ_STT_SILENCE_RMS")); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			return f
+		}
+	}
+	return defaultSilenceRMSThreshold
+}
+
+// rmsAmplitude computes the root-mean-square amplitude of little-endian signed
+// 16-bit mono PCM. Returns 0 for empty or odd-length input.
+func rmsAmplitude(pcm []byte) float64 {
+	n := len(pcm) / 2
+	if n == 0 {
+		return 0
+	}
+	var sumSquares float64
+	for i := 0; i < n; i++ {
+		sample := int16(binary.LittleEndian.Uint16(pcm[i*2:]))
+		f := float64(sample)
+		sumSquares += f * f
+	}
+	return math.Sqrt(sumSquares / float64(n))
 }
 
 func apiURL() string {
@@ -293,6 +329,16 @@ func STT(req sr.SpeechRequest) (string, error) {
 		if done {
 			break
 		}
+	}
+
+	// Silence gate: if the captured audio is near-silent, skip transcription
+	// entirely. This avoids Whisper hallucinating phrases like "thank you" or
+	// "bye" on empty audio from a false wake-word trigger.
+	rms := rmsAmplitude(req.DecodedMicData)
+	if rms < silenceThreshold() {
+		logger.Println(fmt.Sprintf("Bot %s (Groq) skipping near-silent audio (rms=%.1f < %.1f)",
+			req.Device, rms, silenceThreshold()))
+		return "", nil
 	}
 
 	pcmBuf := &writerseeker.WriterSeeker{}

--- a/chipper/start.sh
+++ b/chipper/start.sh
@@ -62,6 +62,12 @@ if [[ ${STT_SERVICE} == "leopard" ]]; then
     else
         /usr/local/go/bin/go run -tags $GOTAGS -ldflags="${GOLDFLAGS}" cmd/experimental/whisper/main.go
     fi
+    elif [[ ${STT_SERVICE} == "groq" ]]; then
+    if [[ -f ./chipper ]]; then
+        ./chipper
+    else
+        /usr/local/go/bin/go run -tags $GOTAGS -ldflags="${GOLDFLAGS}" cmd/groq/main.go
+    fi
     elif [[ ${STT_SERVICE} == "whisper.cpp" ]]; then
     if [[ -f ./chipper ]]; then
         export C_INCLUDE_PATH="../whisper.cpp"

--- a/setup.sh
+++ b/setup.sh
@@ -144,6 +144,7 @@ function getSTT() {
         echo "2: Picovoice Leopard (local, usage collected, accurate, account signup required)"
         echo "3: VOSK (local, accurate, multilanguage, fast, recommended)"
         echo "4: Whisper (local, accurate, multilanguage, recommended ONLY for more powerful hardware, please don't run on a Pi)"
+        echo "5: Groq Whisper (cloud, very accurate, multilanguage, fast even on low-power hardware like a Pi, free API key required)"
         echo
         read -p "Enter a number (3): " sttServiceNum
         if [[ ! -n ${sttServiceNum} ]]; then
@@ -161,6 +162,8 @@ function getSTT() {
             sttService="vosk"
             elif [[ ${sttServiceNum} == "4" ]]; then
             sttService="whisper"
+            elif [[ ${sttServiceNum} == "5" ]]; then
+            sttService="groq"
         else
             echo
             echo "Choose a valid number, or just press enter to use the default number."
@@ -263,6 +266,21 @@ function getSTT() {
 	cmake --build build_go --config Release
         cd ${origDir}
         echo "export WHISPER_MODEL=$whispermodel" >> ./chipper/source.sh
+        elif [[ ${sttService} == "groq" ]]; then
+        function groqApiPrompt() {
+            echo
+            echo "Create a free account at https://console.groq.com/keys and enter the API key it gives you."
+            echo
+            read -p "Enter your Groq API key: " groqKey
+            if [[ ! -n ${groqKey} ]]; then
+                echo
+                echo "You must enter a key."
+                groqApiPrompt
+            fi
+        }
+        groqApiPrompt
+        echo "export STT_SERVICE=groq" >> ./chipper/source.sh
+        echo "export GROQ_API_KEY=${groqKey}" >> ./chipper/source.sh
     else
         echo "export STT_SERVICE=coqui" >> ./chipper/source.sh
         if [[ ! -f ./stt/completed ]]; then
@@ -590,6 +608,10 @@ function setupSystemd() {
         export CGO_LDFLAGS="-L$(pwd)/../whisper.cpp"
         export CGO_CFLAGS="-I$(pwd)/../whisper.cpp"
         /usr/local/go/bin/go build -tags $GOTAGS -ldflags="${GOLDFLAGS}" cmd/experimental/whisper.cpp/main.go
+        elif [[ ${STT_SERVICE} == "groq" ]]; then
+        echo "wire-pod.service created, building chipper with Groq cloud STT service..."
+        export CGO_ENABLED=1
+        /usr/local/go/bin/go build -tags $GOTAGS -ldflags="${GOLDFLAGS}" cmd/groq/main.go
     else
         echo "wire-pod.service created, building chipper with Coqui STT service..."
         export CGO_LDFLAGS="-L/root/.coqui/"


### PR DESCRIPTION
Adds a new speech-to-text engine, groq, that streams Vector's captured audio to Groq's OpenAI-compatible transcription API (running whisper-large-v3) instead of running a model locally.
This gives low-power hosts — a Raspberry Pi 3B+ in particular — accurate, open-vocabulary recognition that isn't achievable with a local model on 1 GB of ARM. The Pi only captures and forwards audio; Groq does the inference. It also handles accented English and non-English languages (e.g. Greek) far better than the small local VOSK model, and is fast enough that there's no perceptible delay on short commands.
What's included
chipper/pkg/wirepod/stt/groq/Groq.go — the engine. Implements the standard interface (Name, Init, STT). Drains the audio stream to end-of-speech, wraps the PCM as WAV, POSTs it, parses the response, lowercases it. Includes brief retries on transient errors and fail-fast on client errors like a bad key.
chipper/cmd/groq/main.go — entry point, matching the other engines.
chipper/start.sh — adds the groq branch to STT dispatch.
setup.sh — adds Groq Whisper as menu option 5, an API-key prompt, and the build step.
Configuration (env vars in source.sh)
GROQ_API_KEY (required)
GROQ_STT_MODEL (default whisper-large-v3; also whisper-large-v3-turbo)
GROQ_STT_LANGUAGE (default auto-detect; e.g. en, el)
GROQ_STT_PROMPT (optional biasing prompt)
GROQ_API_URL (override for OpenAI-compatible endpoints)
Notes
No new Go dependencies — reuses the audio libraries the existing Whisper module already pulls in.
The build is CGO but does not link any local STT library, so there's no libvosk/whisper.cpp runtime requirement.
Testing
Built and run on a Raspberry Pi 3B+ (Debian trixie, aarch64) against a live Vector. Confirmed correct transcription of short commands with no perceptible latency, custom intents matching as before, and clean startup/error logging