### PR TITLE
webroot UI: unified design system, mobile-first chrome, frameless FPV control cockpit (100% drop-in)

### DIFF
--- a/chipper/webroot/css/control.css
+++ b/chipper/webroot/css/control.css
@@ -1,0 +1,734 @@
+/* ============================================================
+   Vector Control — touch cockpit
+   Copied from webroot/sdkapp/control.html inline <style>
+   (cockpit-only rules). Design tokens live in style.css —
+   do not redeclare a conflicting :root palette here.
+   Link after style.css from control.html only.
+   ============================================================ */
+
+/* ---------- top bar (control chrome) ---------- */
+.ctl-head {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  height: calc(52px + env(safe-area-inset-top));
+  padding: env(safe-area-inset-top) 12px 0 12px;
+  background: rgba(16, 18, 21, .92);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--line);
+}
+.ctl-head .back-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 12px;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  color: var(--ink);
+  text-decoration: none;
+  font-size: 15px;
+  cursor: pointer;
+}
+.ctl-head h1 {
+  margin: 0;
+  flex: 1;
+  font-size: 16px;
+  font-weight: 700;
+  text-align: left;
+}
+
+/* the master switch: behavior control */
+.ctl-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 38px;
+  padding: 0 14px;
+  margin: 0;
+  width: auto;
+  border-radius: 12px;
+  border: 1px solid var(--line);
+  background: var(--panel);
+  color: var(--muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  cursor: pointer;
+  user-select: none;
+  transition: all .15s ease;
+}
+.ctl-toggle .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--muted);
+  transition: all .15s ease;
+}
+.ctl-toggle.on {
+  color: #06211e;
+  background: var(--teal);
+  border-color: var(--teal);
+}
+.ctl-toggle.on .dot {
+  background: #06211e;
+  box-shadow: 0 0 8px rgba(6, 33, 30, .6);
+}
+
+/* ---------- cockpit (camera + pads) ---------- */
+#cockpit { position: relative; margin: 12px; }
+
+.cam-shell {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  background: #05070a;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+#camStream {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+#camStream img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+.cam-idle {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  color: var(--muted);
+  pointer-events: none;
+}
+.cam-idle i { font-size: 34px; opacity: .5; }
+.cam-idle span {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 11px;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+}
+.cam-hud {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  right: 8px;
+  z-index: 5;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  pointer-events: none;
+}
+.cam-hud > * { pointer-events: auto; }
+.hud-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  height: 34px;
+  min-height: 34px;
+  padding: 0 12px;
+  margin: 0;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, .14);
+  background: rgba(10, 12, 15, .6) !important; /* style.css / focus states must not repaint this */
+  backdrop-filter: blur(6px);
+  color: var(--ink);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  width: auto;
+  letter-spacing: normal;
+  text-transform: none;
+}
+/* active state: font color change ONLY — no background, no border shift */
+.hud-btn.rec {
+  color: var(--teal);
+  text-shadow: 0 0 8px rgba(53, 224, 207, .4);
+}
+.hud-btn:focus, .hud-btn:active,
+.ctl-toggle:focus, .ctl-toggle:active {
+  outline: none;
+  transform: none;
+  filter: none;
+}
+.hud-btn:focus-visible,
+.ctl-toggle:focus-visible {
+  outline: 2px solid var(--teal);
+  outline-offset: 2px;
+}
+#ctlHint {
+  position: absolute;
+  left: 50%;
+  bottom: 10px;
+  transform: translateX(-50%);
+  z-index: 6;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(255, 180, 84, .14);
+  border: 1px solid rgba(255, 180, 84, .5);
+  color: var(--amber);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 10.5px;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  opacity: 0;
+  transition: opacity .2s ease;
+  pointer-events: none;
+}
+#ctlHint.show { opacity: 1; }
+
+/* Say Text input: same content width as mirror-mode labels / sayControlHint
+   (card column width, ~467px at 950px viewports — NOT a full-row span).
+   Lift style.css desktop `input.tinput { max-width: 420px }` only for this field. */
+#sayTextCard .say-field-wrap {
+  width: 100%;
+  max-width: none;
+  box-sizing: border-box;
+}
+#sayTextCard #textSay,
+#sayTextCard #textSay.tinput,
+#sayTextCard input.tinput#textSay,
+#sayTextCard input#textSay[type="text"] {
+  display: block;
+  width: 100% !important;
+  max-width: none !important; /* was capped at 420px; labels use full card ~467px */
+  min-width: 0;
+  box-sizing: border-box;
+}
+
+/* Say Text — lock hint when Take control is off */
+.ctl-field-hint {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 10px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: rgba(255, 180, 84, .1);
+  border: 1px solid rgba(255, 180, 84, .4);
+  color: var(--amber);
+  font-size: 13px;
+  line-height: 1.35;
+  text-align: left;
+  width: 100%;
+  box-sizing: border-box;
+}
+.ctl-field-hint[hidden] { display: none !important; }
+.ctl-field-hint i {
+  flex: 0 0 auto;
+  font-size: 12px;
+  opacity: .9;
+}
+.ctl-field-hint.pulse {
+  animation: sayHintPulse .55s ease;
+}
+@keyframes sayHintPulse {
+  0%, 100% { transform: scale(1); box-shadow: none; }
+  40% {
+    transform: scale(1.02);
+    box-shadow: 0 0 0 3px rgba(255, 180, 84, .25);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .ctl-field-hint.pulse { animation: none; }
+}
+#sayTextCard.needs-control .say-field-wrap {
+  position: relative;
+  cursor: not-allowed;
+}
+#sayTextCard.needs-control #textSay {
+  opacity: .55;
+  cursor: not-allowed;
+}
+#saySpeakBtn:disabled {
+  opacity: .45;
+  cursor: not-allowed;
+  filter: none;
+  transform: none;
+}
+
+/* ---------- controller deck ---------- */
+.deck {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 14px;
+  touch-action: none;
+}
+
+/* 8-way touch D-pad */
+#dpad {
+  position: relative;
+  width: min(46vw, 210px);
+  height: min(46vw, 210px);
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 42%, #232932, #171b20 68%);
+  border: 1px solid var(--line);
+  box-shadow: inset 0 4px 14px rgba(0, 0, 0, .5), 0 2px 8px rgba(0, 0, 0, .35);
+  touch-action: none;
+  user-select: none;
+}
+#dpad .arrow {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  color: var(--muted);
+  font-size: 15px;
+  transform: translate(-50%, -50%) rotate(var(--r)) translateY(calc(min(46vw, 210px) / -2 + 20px));
+  transition: color .1s ease, text-shadow .1s ease;
+  pointer-events: none;
+}
+#dpad.d-N .a-N, #dpad.d-NE .a-N, #dpad.d-NE .a-E,
+#dpad.d-E .a-E, #dpad.d-SE .a-S, #dpad.d-SE .a-E,
+#dpad.d-S .a-S, #dpad.d-SW .a-S, #dpad.d-SW .a-W,
+#dpad.d-W .a-W, #dpad.d-NW .a-N, #dpad.d-NW .a-W {
+  color: var(--teal);
+  text-shadow: 0 0 10px rgba(53, 224, 207, .8);
+}
+#dpad .nub {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 34%;
+  height: 34%;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 32%, #333b46, #1c2127 70%);
+  border: 1px solid #39414c;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, .5);
+  transition: transform .06s ease;
+  pointer-events: none;
+}
+#dpad.active .nub {
+  border-color: var(--teal);
+  box-shadow: 0 0 14px rgba(53, 224, 207, .35), 0 4px 10px rgba(0, 0, 0, .5);
+}
+
+/* lift / head paddle cluster (gamepad ABXY layout) */
+#paddles {
+  position: relative;
+  width: min(46vw, 210px);
+  height: min(46vw, 210px);
+  flex: 0 0 auto;
+  touch-action: none;
+  user-select: none;
+}
+.pad-btn {
+  position: absolute;
+  width: 47%;
+  height: 47%;
+  border-radius: 50%;
+  border: 1px solid var(--line);
+  background: radial-gradient(circle at 45% 35%, #262d36, #181c22 75%);
+  color: var(--ink);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1px;
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: normal;
+  text-transform: none;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, .4);
+  touch-action: none;
+  transition: transform .05s ease;
+  padding: 0;
+  margin: 0;
+  min-height: 0;
+}
+.pad-btn small {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 8.5px;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.pad-btn:active,
+.pad-btn.held {
+  transform: scale(.94);
+  border-color: var(--teal);
+  color: var(--teal);
+  box-shadow: 0 0 14px rgba(53, 224, 207, .3), 0 3px 8px rgba(0, 0, 0, .4);
+  filter: none;
+}
+/* rotated-45° cluster: 2×2 grid — UPs on top, DOWNs on bottom,
+   head on the left column, lift on the right column */
+.pad-btn.p-headup   { top: 0;    left: 0;  }
+.pad-btn.p-liftup   { top: 0;    right: 0; }
+.pad-btn.p-headdown { bottom: 0; left: 0;  }
+.pad-btn.p-liftdown { bottom: 0; right: 0; }
+
+.deck-label {
+  margin-top: 4px;
+  text-align: center;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 9.5px;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.deck-col {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex: 0 0 auto;
+}
+
+/* ---------- control card extras ---------- */
+.card > button,
+.card .center > button,
+#uploadButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: 10px 18px;
+  margin: 6px 6px 0 0;
+  background: var(--teal);
+  color: #06211e;
+  border: none;
+  border-radius: 12px;
+  font-size: 14px;
+  font-weight: 700;
+}
+audio { width: 100%; margin-top: 8px; }
+
+/* keyboard help chip (desktop only) */
+#keysKey {
+  margin-top: 8px;
+  padding: 10px 12px;
+  background: var(--panel-2);
+  border: 1px dashed var(--line);
+  border-radius: 10px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  color: var(--muted);
+}
+.kb-only { display: none !important; }
+@media (hover: hover) and (pointer: fine) {
+  .kb-only { display: block !important; }
+  button.kb-only,
+  .ctl-help.kb-only { display: inline-flex !important; }
+}
+
+/* header ? help button */
+.ctl-help {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  min-height: 38px;
+  padding: 0;
+  margin: 0;
+  border-radius: 12px;
+  border: 1px solid var(--line);
+  background: var(--panel);
+  color: var(--muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 1;
+  cursor: pointer;
+  flex: 0 0 auto;
+  box-shadow: none;
+}
+.ctl-help:hover {
+  color: var(--ink);
+  border-color: #3a434e;
+  background: var(--panel-2);
+}
+.ctl-help:focus-visible {
+  outline: 2px solid var(--fg-color);
+  outline-offset: 2px;
+}
+
+/* inline ? next to "Keyboard Controls" heading */
+.kb-help-inline {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  min-height: 26px;
+  margin-left: 8px;
+  padding: 0;
+  vertical-align: middle;
+  border-radius: 8px;
+  border: 1px solid var(--line);
+  background: var(--panel-2);
+  color: var(--muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: none;
+}
+.kb-help-inline:hover {
+  color: var(--fg-color);
+  border-color: var(--fg-color);
+}
+
+/* keyboard help modal */
+.kb-help-modal[hidden] { display: none !important; }
+.kb-help-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+}
+.kb-help-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, .55);
+  backdrop-filter: blur(4px);
+}
+.kb-help-panel {
+  position: relative;
+  z-index: 1;
+  width: min(420px, 100%);
+  max-height: min(90vh, 560px);
+  overflow: auto;
+  padding: 18px 18px 16px;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  box-shadow: 0 16px 48px rgba(0, 0, 0, .45);
+}
+.kb-help-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+.kb-help-head h2 {
+  margin: 0;
+  flex: 1;
+  font-size: 17px;
+  font-weight: 700;
+  color: var(--ink);
+  text-align: left;
+}
+.kb-help-close {
+  width: 36px;
+  height: 36px;
+  min-height: 36px;
+  padding: 0;
+  margin: 0;
+  border-radius: 10px;
+  border: 1px solid var(--line);
+  background: var(--panel-2);
+  color: var(--ink);
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+  box-shadow: none;
+}
+.kb-help-lead,
+.kb-help-note {
+  margin: 0 0 12px;
+  font-size: 13.5px;
+  color: var(--muted);
+  line-height: 1.45;
+  text-align: left;
+}
+.kb-help-note { font-size: 12.5px; }
+.kb-help-map {
+  list-style: none;
+  margin: 0 0 14px;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.kb-help-map li {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  background: var(--panel-2);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  font-size: 13.5px;
+  color: var(--ink);
+  text-align: left;
+}
+.kb-help-map li span { color: var(--muted); flex: 1 1 120px; }
+.kb-help-map kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 28px;
+  height: 28px;
+  padding: 0 8px;
+  border-radius: 8px;
+  border: 1px solid var(--line);
+  background: var(--bg);
+  color: var(--fg-color);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  font-weight: 700;
+  box-shadow: 0 2px 0 var(--line);
+}
+.kb-help-done {
+  width: 100%;
+  min-height: 44px;
+  margin: 0;
+  background: var(--fg-color);
+  color: #06211e;
+  border: none;
+  border-radius: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: none;
+}
+.kb-help-done:hover { filter: brightness(1.06); }
+
+/* ---------- desktop hover (control-only) ---------- */
+@media (hover: hover) and (pointer: fine) {
+  .hud-btn:hover { border-color: rgba(255, 255, 255, .3); }
+  .ctl-toggle:hover { border-color: #3a434e; color: var(--ink); }
+  .ctl-toggle.on:hover { filter: brightness(1.06); color: #06211e; }
+  .pad-btn:hover { border-color: #3a434e; }
+  .card > button:hover,
+  #uploadButton:hover { filter: brightness(1.08); }
+  .ctl-head .back-btn:hover {
+    background: var(--panel-2);
+    border-color: #3a434e;
+  }
+}
+
+/* ---------- desktop cockpit grid ---------- */
+@media (min-width: 880px) {
+  #content { max-width: 1080px; }
+
+  /* cockpit: big camera left, controller column right */
+  #sdkActions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 14px;
+    padding: 0 12px;
+  }
+  #cockpit {
+    grid-column: 1 / -1;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 280px;
+    gap: 16px;
+    align-items: stretch;
+    margin: 14px 0 0 0;
+  }
+  .cam-shell { aspect-ratio: auto; min-height: 440px; }
+  .deck {
+    margin-top: 0;
+    flex-direction: column;
+    justify-content: center;
+    gap: 30px;
+    padding: 20px 0;
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+  }
+  #dpad, #paddles { width: 200px; height: 200px; }
+  #dpad .arrow {
+    transform: translate(-50%, -50%) rotate(var(--r)) translateY(-80px);
+  }
+
+  .card { margin: 0; }
+  .card.kb-only { display: block; }
+  #keysKey { max-width: none; }
+}
+
+/* ============================================================
+   LANDSCAPE COCKPIT — phone rotated = FPV controller.
+   Camera fills the screen, pads become translucent overlays.
+   ============================================================ */
+@media (orientation: landscape) and (max-height: 560px) and (pointer: coarse) {
+  body { overflow: hidden; }
+  .ctl-head { display: none; }
+  .card { display: none; }
+  #content { max-width: none; padding: 0; }
+
+  #cockpit {
+    position: fixed;
+    inset: 0;
+    margin: 0;
+    z-index: 60;
+  }
+  .cam-shell {
+    position: absolute;
+    inset: 0;
+    aspect-ratio: auto;
+    border: none;
+    border-radius: 0;
+  }
+  #camStream img { object-fit: cover; }
+  .cam-hud {
+    top: calc(8px + env(safe-area-inset-top));
+    left: calc(10px + env(safe-area-inset-left));
+    right: calc(10px + env(safe-area-inset-right));
+  }
+
+  .deck {
+    position: absolute;
+    inset: 0;
+    margin: 0;
+    pointer-events: none;
+  }
+  .deck-col {
+    position: absolute;
+    bottom: calc(16px + env(safe-area-inset-bottom));
+    pointer-events: auto;
+  }
+  .deck-col.left  { left: calc(18px + env(safe-area-inset-left)); }
+  .deck-col.right { right: calc(18px + env(safe-area-inset-right)); }
+  .deck-label {
+    color: rgba(233, 237, 241, .55);
+    text-shadow: 0 1px 3px rgba(0, 0, 0, .8);
+  }
+
+  #dpad {
+    width: min(38vh, 200px);
+    height: min(38vh, 200px);
+    background: radial-gradient(circle at 50% 42%, rgba(35, 41, 50, .72), rgba(23, 27, 32, .72) 68%);
+    backdrop-filter: blur(4px);
+  }
+  #dpad .arrow {
+    transform: translate(-50%, -50%) rotate(var(--r)) translateY(calc(min(38vh, 200px) / -2 + 18px));
+  }
+  #paddles {
+    width: min(38vh, 200px);
+    height: min(38vh, 200px);
+  }
+  .pad-btn {
+    background: radial-gradient(circle at 45% 35%, rgba(38, 45, 54, .78), rgba(24, 28, 34, .78) 75%);
+    backdrop-filter: blur(4px);
+  }
+}

--- a/chipper/webroot/css/style.css
+++ b/chipper/webroot/css/style.css
@@ -1,349 +1,228 @@
-@import url("wing.css");
+/* ============================================================
+   wire-pod global design system
+   Copied from gold templates:
+     webroot/sdkapp/settings.html inline <style>
+     webroot/sdkapp/control.html shared shell/tokens
+   Plus legacy JS-required utilities from previous style.css.
+   Control cockpit lives in control.css — do not add it here.
+   ============================================================ */
 
-@font-face{
+@font-face {
   font-family: 'DroidSans';
   src: url('DroidSans.woff') format('woff');
-  /*font license Apache V2.00: https://www.fontsquirrel.com/license/droid-sans*/
+  /* font license Apache V2.00: https://www.fontsquirrel.com/license/droid-sans */
 }
 
-@font-face{
+@font-face {
   font-family: 'IBMVGA';
   src: url('PxPlus_IBM_VGA_8x16.ttf') format('truetype');
   /* VileR's old school font pack - int10h.org */
 }
 
-@font-face{
+@font-face {
   font-family: 'H1Weird';
   src: url('h1Font.ttf') format('truetype');
+  /* classic Wire-Pod hero / splash wordmark */
 }
 
-/* {
-  "TIP_OVER_TEAL" :
-  #00d16d
-    { "Hue" : 0.42, "Saturation" : 1.00 },
-  "OVERFIT_ORANGE" :
-    { "Hue" : 0.05, "Saturation" : 0.95 },
-  "UNCANNY_YELLOW" :
-    { "Hue" : 0.11, "Saturation" : 1.00 },
-  "NON_LINEAR_LIME" :
-    { "Hue" : 0.21, "Saturation" : 1.00 },
-  "SINGULARITY_SAPPHIRE" :
-    { "Hue" : 0.57, "Saturation" : 1.00 },
-  "FALSE_POSITIVE_PURPLE" :
-  #e237e6
-    { "Hue" : 0.83, "Saturation" : 0.76 },
-  "CONFUSION_MATRIX_GREEN" :
-    { "Hue" : 0.30, "Saturation" : 1.00 }
-} */
-
+/* ---------- design tokens (gold) ---------- */
 :root {
-  --bg-color: #1e1e1e;
-  --body-font-family: 'DroidSans', sans-serif;
-  --bg-color-alt: rgba(196,196,196,1);        /* light gray #C4C4C4*/
-  --button-color: rgba(75,75,75,1);        /* dark gray #4B4B4B */
-  --button-color-alt: rgba(164,164,164,1);    /* light gray #A4A4A4 */
-  --fg-color: #00ff80;            /* light green 33ED6D */
-  --medium-battery: #ced100;        /* bright yellow */
-  --low-battery: #ff0000;        /* bright red */
-  --fg-color-alt: rgba(51,237,109,.05);        /* light green 33ED6D */
-  --text-color: rgba(255,255,255,1);        /* white #FFFFFF */
-  --text-color-alt: rgba(34,34,34,1);        /* black #000000 */
+  --bg: #101215;
+  --panel: #191d22;
+  --panel-2: #21262d;
+  --line: #2b323b;
+  --ink: #e9edf1;
+  --muted: #8b95a1;
+  /* ui.js mutates --fg-color; settings.js reads --fg-color + --gg-color-alt */
+  --fg-color: #35e0cf;
+  --gg-color-alt: #6b7480;
+  --teal: var(--fg-color);
+  --amber: #ffb454;
+  --danger: #ff5d5d;
+  --radius: 14px;
+  --dock-h: 74px;
+  --head-h: 52px;
+  /* ui.js / legacy aliases */
+  --bg-color: var(--bg);
+  --body-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --medium-battery: #ced100;
+  --low-battery: #ff0000;
 }
 
-/* Modified icon styles */
-.selectedicon {
-  color: var(--fg-color);
-}
+* { box-sizing: border-box; -webkit-tap-highlight-color: transparent; }
 
-.notselectedicon {
-  color: var(--fg-color);
-  filter: drop-shadow(0 0 8px var(--fg-color));
-}
-
-.notselectedicon:hover {
-  color: var(--text-color); /* White for hover */
-}
-
-.main-nav-child:hover .selectedicon {
-  color: var(--fg-color);
-}
-
-.selectedicon, .notselectedicon {
-  transition: all 0s ease-in-out;
-}
-
-.dropdown {
-  position: relative;
-  display: inline-block;
-}
-
-button:disabled, button[type="submit"]:disabled {
-  background: var(--bg-color);
-  color : var(--bg-color-alt);
-}
-button, button[type="submit"] {
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--ink);
   font-family: var(--body-font-family);
-  font-size: 0.8em;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
-  width: 170px;
-  border: 2px solid var(--fg-color);
-  background-color: var (--button-color);
-  color: var(--text-color);
-  transition: border-color 0.3s, background-color 0.3s;
+  font-size: 16px;
+  line-height: 1.45;
 }
 
-button:hover, button[type="submit"]:disabled {
-  border-color: var(--fg-color-alt);
-  background-color: var(--fg-color);
-  color: var(--text-color-alt);
+/* neutralise old shell layout */
+#outer {
+  width: 100%;
+  max-width: none;
+  margin: 0;
+  padding: 0;
+  background: transparent;
 }
-
-.dropdown-content {
-  display: none;
-  position: absolute;
-  background-color: var(--bg-color);
-  min-width: 160px;
-  box-shadow: 0px 8px 16px 0px var(--fg-color-alt);
-  padding: 12px 16px;
-  z-index: 1;
+#content {
+  width: 100%;
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 0 0 48px 0;
+  background: transparent;
+  box-shadow: none;
 }
-
-.dropdown:hover .dropdown-content {
-  display: block;
+#content > hr { display: none; }
+hr {
+  border: none;
+  border-top: 1px solid var(--line);
+  margin: 14px 0;
 }
-
-input[type="text"], input[type="file"], select {
-  background-color: #2d2d2d;
-  color: #ffffff;
-  font-family: var(--body-font-family);
-  font-size: 1.0em;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
-  text-align: center;
-  border: 2px solid var(--fg-color);
-  box-sizing: border-box;
-  transition: border-color 0.3s;
+hr.small-hr {
+  margin: 10px 0;
+  opacity: .7;
+  width: auto;
+  border: none;
+  border-top: 1px solid var(--line);
 }
-
-input[type="text"]:hover, input[type="file"]:hover, select:hover,
-input[type="text"]:focus, input[type="file"]:focus, select:focus {
-  border-color: white;
-  border: 2px solid;
-  box-sizing: border-box;
-  transition: border-color 0.3s;
-}
-
-input[type='text']:disabled {
-  cursor: not-allowed;
-}
-
-.small-hr {
-  border: 1px solid #3e3e3e;
-  width: 30%;
-}
-
-.log-hr {
+hr.log-hr {
   margin-bottom: 50px;
 }
 
-input[type="file"] {
-  width: auto;
-}
+a { color: var(--fg-color); }
+a:hover { text-decoration: none; color: var(--fg-color); }
 
-/* input[type="text"] {
-  width: ;
-} */
-
-select {
-  width: auto;
-}
-
-body {
-  background-color: var(--bg-color);
-  font-family: var(--body-font-family);
-  font-size: 1.8em;
-  display: flex;
-  justify-content: center;
+/* ---------- shared back button ---------- */
+.back-btn {
+  display: inline-flex;
   align-items: center;
-  min-height: 100vh;
-  margin: 0;
-  flex-wrap: wrap;
-  text-align: center;
-  padding-top: env(safe-area-inset-top);
-}
-
-
-h1, h2, h3, h4, small, p, li, label {
-  font-family: var(--body-font-family);
-  color: var(--text-color);
-}
-
-h2, h3 {
-  margin-top: 0px;
-  margin-bottom: 0px;
-}
-
-.desc {
-  color: var(--bg-color-alt);
-}
-
-h1 {
-  color: var(--fg-color);
-  font-family: "H1Weird", sans-serif;
-  font-size: 3em;
-  font-weight: bold;
-  letter-spacing: 0em;
-  text-align: center;
-}
-
-textarea {
-  background-color: #2d2d2d;
-  color: #ffffff;
-  font-family: var(--body-font-family);
-  font-size: 0.9em;
-  height: 280px;
-  border: 2px solid var(--fg-color);
-  box-sizing: border-box;
-  transition: border-color 0.3s;
-}
-
-textarea:hover, textarea:focus {
-  border-color: white;
-  border: 2px solid;
-  box-sizing: border-box;
-  transition: border-color 0.3s;
-}
-
-/* p {
-  font-size: 1.2em;
-} */
-
-.content {
-  display: none;
-}
-
-.wrap {
-  overflow: hidden !important;
-  white-space: nowrap !important;
-}
-
-hr {
-  border: 2px solid #3e3e3e;
-  /* background-image: linear-gradient(to right, var(--fg-color-alt), var(--fg-color), var(--fg-color-alt)); */
-}
-
-a {
-  color:var(--fg-color);
-}
-a:hover {
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 12px;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  color: var(--ink);
   text-decoration: none;
-  color: var(--fg-color);
-}
-/*
-ul {
-  list-style-type:none;
-} */
-
-ul, li {
-  /* list-style-type: none; */
-  list-style-position:inside;
-  margin:0;
-  padding:0;
-}
-
-.tinput {
-  width: 315px !important;
-  background-color: var(--button-color) !important;
-  color: var(--text-color) !important;
-  border: 2px solid var(--fg-color); /* accent color */
-}
-
-.tinputauth {
-  width: 499px !important;
-  background-color: var(--button-color) !important;
-  color: var(--text-color) !important;
-  border: 2px solid var(--fg-color); /* accent color */
-}
-
-canvas{
-  width:750px !important;
-  height:400px !important;
-}
-
-/* RADIO BUTTON ######################### */
-input[type='radio'] {
-  appearance: none;
-  top: 13.333333px;
-  right: 50%;
-  bottom: 0px;
-  left: 0;
-  margin-top: 0px;
-  height: 40px;
-  width: 40px;
-  transition: all .2s ease;
-  background: var(--button-color);
-  border: none;
+  font-size: 15px;
   cursor: pointer;
-  outline: none;
-  position: relative;
-  z-index: 1000;
-  border-radius: 50%;
-  border: 1px solid var(--button-color-alt);
 }
 
-input[type='radio']:checked:after {
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-  background-color: var(--fg-color);
-  content: '';
-  display: inline-block;
-}
-
-input[type='radio']:disabled {
-  cursor: not-allowed;
-}
-
-input[type='radio']:disabled:after {
-  background-color: var(--button-color-alt);
-  cursor: not-allowed;
-}
-
-/* ###################################### */
-#username, #password {
-  width: 499px !important;
-  background-color: var(--bg-color-alt) !important;
-  color: var(--text-color) !important;
-  border: 2px solid var(--fg-color); /* accent color */
-}
-
-#botAuth {
-  color: var(--text-color);
-}
-
-#content {
-  width: 950px !important;
-  /* word-break:break-all !important; */
-  /* word-wrap: break-all !important; */
-  white-space:normal !important;
-}
-#outer {
-  width: 100%;
+/* ---------- sticky app header (settings / hub) ---------- */
+.app-head {
+  position: sticky;
+  top: 0;
+  z-index: 40;
   display: flex;
-  justify-content: center;
-  height: 100vh; /* Keeps things at the top*/
-  align-items: start;
-}
-
-#botStats {
-  width: 100%;
-  height: 50px;
-  display: flex;
-  justify-content: center;
   align-items: center;
-  gap: 30px;
+  gap: 10px;
+  height: calc(var(--head-h) + env(safe-area-inset-top));
+  padding: env(safe-area-inset-top) 12px 0 12px;
+  background: rgba(16, 18, 21, .92);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--line);
+}
+/* small breathing room above header content on non-notch screens */
+.app-head {
+  padding-top: max(env(safe-area-inset-top), 4px);
+  height: calc(var(--head-h) + max(env(safe-area-inset-top), 4px));
+}
+.app-head .back-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 12px;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  color: var(--ink);
+  text-decoration: none;
+  font-size: 15px;
+}
+.app-head h1 {
+  margin: 0;
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: .02em;
+  flex: 1;
+  text-align: left;
+  color: var(--ink);
 }
 
-/* a simple gif loading from /assets/cloudface.gif and is 60x60px */
+/* ---------- battery base (battery.js markup) ---------- */
+#botStats {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  height: 100%;
+  max-width: 50%;
+  position: relative;
+}
+#botStats .batteryContainer {
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  gap: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+#botStats .batteryOutline {
+  width: 54px;
+  height: 22px;
+  border-radius: 4px;
+  outline: 2px solid var(--line);
+  outline-offset: 2px;
+  position: relative;
+  flex: 0 0 auto;
+}
+#botStats .batteryOutline::before { border-radius: 4px; }
+/* battery terminal nub: stock puts it at left:102px for a 100px body */
+#botStats .batteryOutline::after {
+  left: 56px;
+  top: 5px;
+  width: 4px;
+  height: 12px;
+  border-radius: 0 2px 2px 0;
+}
+#botStats .batteryLevel { border-radius: 4px; }
+/* charging bolt: stock is 40x40 at left:30px — center it for any width */
+#botStats .charging {
+  width: 18px;
+  height: 18px;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  margin: 0;
+}
+#botStats .chargeTimeRemaining {
+  bottom: 1px;
+  left: 3px;
+  font-size: 8px;
+  line-height: 1;
+}
+#botStats .vectorFace { width: 34px; height: 34px; flex: 0 0 auto; }
+#botStats .botLoader { width: 34px; height: 34px; background-size: 34px 34px; margin: 0; }
+/* tooltip: stock drops it 145px down the page — anchor under the bar */
+#botStats .tooltip {
+  margin-top: 0;
+  top: calc(100% + 6px);
+  right: 0;
+  left: auto;
+  font-size: 11px;
+  text-transform: none;
+  letter-spacing: normal;
+  border: 1px solid var(--line);
+}
+
+/* base battery pieces (used by #botStats overrides + standalone) */
 .botLoader {
   background-image: url('/assets/cloudface.gif');
   background-size: 60px 60px;
@@ -364,17 +243,15 @@ input[type='radio']:disabled:after {
   padding-bottom: 15px;
   gap: 15px;
   cursor: pointer;
+  position: relative;
 }
-
-.batteryContainer:hover .tooltip {
-  display: block;
-}
+.batteryContainer:hover .tooltip { display: block; }
 
 .tooltip {
   position: absolute;
   display: none;
-  background-color: var(--bg-color);
-  color: var(--text-color);
+  background-color: var(--panel);
+  color: var(--ink);
   border-radius: 5px;
   padding: 5px;
   z-index: 1000;
@@ -383,7 +260,7 @@ input[type='radio']:disabled:after {
 }
 
 .batteryOutline {
-  outline: 2px solid var(--text-color);
+  outline: 2px solid var(--ink);
   outline-offset: 2px;
   border-radius: 5px;
   width: 100px;
@@ -393,11 +270,11 @@ input[type='radio']:disabled:after {
 .batteryOutline::before {
   content: '';
   position: absolute;
-  top: 0px;
-  left: 0px;
+  top: 0;
+  left: 0;
   width: 100%;
   height: 100%;
-  background-color: var(--button-color);
+  background-color: var(--panel-2);
   border-radius: 5px;
 }
 .batteryOutline::after {
@@ -407,7 +284,7 @@ input[type='radio']:disabled:after {
   left: 102px;
   width: 6px;
   height: 18px;
-  background-color: var(--text-color);
+  background-color: var(--ink);
 }
 
 .vectorFace {
@@ -420,170 +297,1110 @@ input[type='radio']:disabled:after {
 
 .batteryLevel {
   position: absolute;
-  top: 0px;
-  left: 0px;
+  top: 0;
+  left: 0;
   width: 100%;
   height: 100%;
-  background-color: var(--button-color-alt);
+  background-color: var(--muted);
   border-radius: 5px;
 }
-
-.battery0 {
-  background-color: var(--low-battery);
-}
-
-.battery1 {
-  background-color: var(--medium-battery);
-}
-
-.battery3, .battery2  {
-  background-color: var(--fg-color);
-}
+.battery0 { background-color: var(--low-battery); }
+.battery1 { background-color: var(--medium-battery); }
+.battery3, .battery2 { background-color: var(--fg-color); }
 
 .charging {
   position: absolute;
-  top: 0px;
+  top: 0;
   left: 30px;
   width: 40px;
   height: 40px;
-  /* content is an svg of a lightning bolt */
   content: url('data:image/svg+xml;utf8,<svg width="60" height="60" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 60"><polygon points="20,0 5,33 24,33 15,60 35,27 16,27" fill="white"/></svg>');
-  /* svg drop shadow */
   filter: drop-shadow(0 0 4px rgba(0, 0, 0, 0.4));
 }
 
 .chargeTimeRemaining {
   position: absolute;
-  bottom: 0px;
+  bottom: 0;
   left: 3px;
   font-size: 0.6em;
   color: white;
   text-shadow: 0 0 4px rgba(0, 0, 0, 1);
 }
 
+/* ---------- the dock: sticky, horizontally scrolling tab rail ---------- */
 .main-nav-parent {
+  position: sticky;
+  top: calc(var(--head-h) + max(env(safe-area-inset-top), 4px));
+  z-index: 39;
   display: flex;
-  justify-content: center;
-  flex-wrap: wrap;
-  gap: 20px;
-  margin: 1rem auto;
-  padding: 1rem;
-  text-align: center;
+  flex-wrap: nowrap;
+  gap: 4px;
+  justify-content: flex-start !important;
+  align-items: center;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+  height: var(--dock-h);
+  padding: 8px 10px;
+  background: rgba(16, 18, 21, .94);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--line);
+  margin: 0;
   width: 100%;
-  max-width: 950px;
+  max-width: none;
+  text-align: center;
+  box-sizing: border-box;
+}
+.main-nav-parent::-webkit-scrollbar { display: none; }
+
+/* ---------- dock alignment + swipe affordance (#hub-nav / #dock) ----------
+   Classes from ui.js:
+     .dock-fits     — all tabs fit → center (setup + hub)
+     .dock-overflow — need scroll → flex-start (center + overflow breaks end access)
+     .dock-fade-*   — edge masks when more content that way
+   Never use overflow-x:visible with centered flex — mid-width desktop
+   windows (~428px) could not reach the rightmost tabs. */
+#hub-nav.main-nav-parent,
+#dock.main-nav-parent {
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  -webkit-overflow-scrolling: touch;
+  scroll-padding-inline: 12px;
+  /* default before JS: start-aligned so first paint can scroll if needed */
+  justify-content: flex-start !important;
+}
+/* all chips fit → center both rails (hub + setup) */
+#hub-nav.main-nav-parent.dock-fits,
+#dock.main-nav-parent.dock-fits {
+  justify-content: center !important;
+  /* still auto so a later resize can scroll without a reflow fight */
+  overflow-x: auto;
+}
+/* overflow → must be start-aligned or the trailing tabs are unreachable */
+#hub-nav.main-nav-parent.dock-overflow,
+#dock.main-nav-parent.dock-overflow {
+  justify-content: flex-start !important;
+  overflow-x: auto !important;
+}
+/* real scrollable end-padding (flex padding-right is unreliable for max scrollLeft) */
+#hub-nav.main-nav-parent.dock-overflow::after,
+#dock.main-nav-parent.dock-overflow::after {
+  content: "";
+  flex: 0 0 28px;
+  height: 1px;
+  pointer-events: none;
+}
+/* measuring pass: force start so scrollWidth is honest while centered */
+#hub-nav.main-nav-parent.dock-measuring,
+#dock.main-nav-parent.dock-measuring {
+  justify-content: flex-start !important;
+}
+
+#hub-nav.main-nav-parent.dock-fade-right:not(.dock-fade-left),
+#dock.main-nav-parent.dock-fade-right:not(.dock-fade-left) {
+  -webkit-mask-image: linear-gradient(
+    to right,
+    #000 0%,
+    #000 calc(100% - 36px),
+    transparent 100%
+  );
+  mask-image: linear-gradient(
+    to right,
+    #000 0%,
+    #000 calc(100% - 36px),
+    transparent 100%
+  );
+}
+#hub-nav.main-nav-parent.dock-fade-left:not(.dock-fade-right),
+#dock.main-nav-parent.dock-fade-left:not(.dock-fade-right) {
+  -webkit-mask-image: linear-gradient(
+    to right,
+    transparent 0%,
+    #000 36px,
+    #000 100%
+  );
+  mask-image: linear-gradient(
+    to right,
+    transparent 0%,
+    #000 36px,
+    #000 100%
+  );
+}
+#hub-nav.main-nav-parent.dock-fade-left.dock-fade-right,
+#dock.main-nav-parent.dock-fade-left.dock-fade-right {
+  -webkit-mask-image: linear-gradient(
+    to right,
+    transparent 0%,
+    #000 32px,
+    #000 calc(100% - 36px),
+    transparent 100%
+  );
+  mask-image: linear-gradient(
+    to right,
+    transparent 0%,
+    #000 32px,
+    #000 calc(100% - 36px),
+    transparent 100%
+  );
+}
+/* mobile peek: slightly wider chips → more likely overflow + cut-off last tab */
+@media (max-width: 759px) {
+  #hub-nav.main-nav-parent .main-nav-child a,
+  #dock.main-nav-parent .main-nav-child a {
+    min-width: 70px;
+  }
+}
+/* narrow desktop: show a thin scrollbar so wheel/trackpad users see more exists */
+@media (hover: hover) and (pointer: fine) {
+  #hub-nav.main-nav-parent.dock-overflow,
+  #dock.main-nav-parent.dock-overflow {
+    scrollbar-width: thin;
+    scrollbar-color: var(--line) transparent;
+  }
+  #hub-nav.main-nav-parent.dock-overflow::-webkit-scrollbar,
+  #dock.main-nav-parent.dock-overflow::-webkit-scrollbar {
+    display: block;
+    height: 4px;
+  }
+  #hub-nav.main-nav-parent.dock-overflow::-webkit-scrollbar-thumb,
+  #dock.main-nav-parent.dock-overflow::-webkit-scrollbar-thumb {
+    background: var(--line);
+    border-radius: 4px;
+  }
 }
 
 .main-nav-child {
+  flex: 0 0 auto;
   display: flex;
   flex-direction: column;
   align-items: center;
-  border-radius: 12px;
-  border: 1px solid white;
-  padding: 8px 12px;
-  vertical-align: top;
+  border: none;
+  background: transparent;
+  padding: 0;
+  min-width: 0;
   width: auto;
-  background: rgba(30, 30, 30, 0.6);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  min-width: 85px;
-  transition: all 0.3s ease-in-out;
-  width: 85px;
+  box-shadow: none;
 }
-
-.main-nav-child:has(.selectedicon) {
-  background: rgba(25, 25, 25, 0.9);
-  border: 1px solid var(--fg-color);
-  box-shadow: 0 0 15px rgba(0, 255, 128, 0.1);
-}
-
-.main-nav-child:hover {
-  transform: translateY(-2px);
-  border-color: white;
-  box-shadow: 0 0 15px rgba(255, 255, 255, 0.1)
-}
-
-.main-nav-child i {
-  font-size: 32px;
-  margin-bottom: 8px;
-  transition: all 0.3s ease-in-out;
-}
-
 .main-nav-child a {
-  width: 100%;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  min-width: 66px;
+  height: 58px;
+  padding: 6px 8px;
+  border-radius: 12px;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: .03em;
+  color: var(--muted);
   text-decoration: none;
-  font-size: 100%;
-  color: var(--bg-color-alt);
+  text-align: center;
+  transition: background .15s ease, color .15s ease;
+  user-select: none;
+  width: auto;
 }
-
-.main-nav-child a:hover {
-  color: var(--text-color);
-}
-
 .main-nav-child a i {
-  text-decoration: none;
-  font-size: 60px;
-  /*padding-left: 20px;
-  padding-right: 20px;*/
-  padding-bottom: 10px;
+  font-size: 18px;
+  color: var(--gg-color-alt);
+  transition: color .15s ease, text-shadow .15s ease;
+  margin-bottom: 0;
+  padding-bottom: 0;
 }
-
+.main-nav-child a:active { background: var(--panel-2); }
+.main-nav-child a br { display: none; }
 .main-nav-child a img {
-  width: 40px;
-  height: 40px;
-  margin-bottom: 8px;
+  width: 22px;
+  height: 22px;
+  margin-bottom: 0;
   object-fit: contain;
 }
 
-/* no horizontal scroll on mobile, grid instead of line*/
+/* active tab: teal "eye glow" (settings.js dock-active + hub selectedicon) */
+.main-nav-child a.dock-active { color: var(--ink); background: var(--panel); }
+.main-nav-child a.dock-active i {
+  color: var(--fg-color) !important;
+  text-shadow: 0 0 12px rgba(53, 224, 207, .55);
+}
+.main-nav-child a.dock-active::after {
+  content: "";
+  position: absolute;
+  left: 18px;
+  right: 18px;
+  bottom: 3px;
+  height: 2px;
+  border-radius: 2px;
+  background: var(--fg-color);
+  box-shadow: 0 0 8px rgba(53, 224, 207, .7);
+}
 
-@media screen and (max-width: 768px) {
-  .main-nav-parent {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
-    gap: 15px;
-    padding: 0.5rem;
-    margin: 0;
-    width: 100%;
-  }
-  
-  #outer {
-    max-width: 100vw;
-    overflow-x: hidden;
-    box-sizing: border-box;
-  }
+/* ---------- icon states (main.js updateColor) ----------
+   Only .selectedicon is the active tab.
+   .nowselectedicon / .notselectedicon = inactive (muted).
+   Bugfix: styling nowselectedicon like selected made all hub icons glow. */
+.selectedicon {
+  color: var(--fg-color) !important;
+  text-shadow: 0 0 12px rgba(53, 224, 207, .55);
+  filter: none;
+  transition: color .15s ease, text-shadow .15s ease;
+}
+.nowselectedicon,
+.notselectedicon {
+  color: var(--gg-color-alt) !important;
+  text-shadow: none;
+  filter: none;
+  transition: color .15s ease, text-shadow .15s ease;
+}
+.main-nav-child:hover .selectedicon {
+  color: var(--fg-color) !important;
+}
+.main-nav-child:hover .nowselectedicon,
+.main-nav-child:hover .notselectedicon {
+  color: var(--muted) !important;
+}
+/* tile chrome only for the truly active icon */
+.main-nav-child:has(.selectedicon) a {
+  color: var(--ink);
+  background: var(--panel);
+}
+.main-nav-child:has(.selectedicon) a i {
+  color: var(--fg-color) !important;
+  text-shadow: 0 0 12px rgba(53, 224, 207, .55);
+}
+.main-nav-child:has(.selectedicon) a::after {
+  content: "";
+  position: absolute;
+  left: 18px;
+  right: 18px;
+  bottom: 3px;
+  height: 2px;
+  border-radius: 2px;
+  background: var(--fg-color);
+  box-shadow: 0 0 8px rgba(53, 224, 207, .7);
+}
 
-  #content {
-    width: 100% !important;
-    max-width: 100vw;
-    padding: 0 10px;
-    box-sizing: border-box;
+/* ---------- hub hero / splash (classic Wire-Pod wordmark) ---------- */
+.hub-hero {
+  text-align: center;
+  padding: calc(20px + env(safe-area-inset-top)) 16px 8px;
+}
+.hub-splash {
+  width: 104px;
+  height: 104px;
+  margin: 0 auto 10px;
+  background-image: url('/assets/face.gif');
+  background-size: contain;
+  background-position: center;
+  background-repeat: no-repeat;
+  filter: drop-shadow(0 0 18px rgba(53, 224, 207, .22));
+}
+/* tappable Vector face → home (setup.html default state) */
+a.hub-splash-link {
+  display: block;
+  width: fit-content;
+  margin: 0 auto 10px;
+  text-decoration: none;
+  color: inherit;
+  border-radius: 16px;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+a.hub-splash-link .hub-splash {
+  margin-bottom: 0;
+}
+a.hub-splash-link:focus-visible {
+  outline: 2px solid var(--fg-color);
+  outline-offset: 4px;
+}
+a.hub-splash-link:active .hub-splash {
+  transform: scale(.96);
+  transition: transform .1s ease;
+}
+.hub-logo {
+  margin: 0;
+  font-family: "H1Weird", sans-serif;
+  font-size: clamp(2.4rem, 10vw, 3.25rem);
+  font-weight: bold;
+  letter-spacing: 0;
+  line-height: 1.05;
+  color: var(--fg-color);
+  text-align: center;
+  text-shadow: 0 0 24px rgba(53, 224, 207, .28);
+}
+.hub-tagline {
+  margin: 8px 0 0;
+  font-size: 13px;
+  color: var(--muted);
+  letter-spacing: .04em;
+}
+
+/* ---------- setup.html: classic hero + section page gutters ----------
+   Original title was "Wire-Pod Setup" (H1Weird era). No pre-restyle
+   tagline exists in this repo's git history — do not invent one here.
+   Dock sticks under the (non-sticky) hero; sections use standard card
+   gutters so weather / KG / language match the rest of the app. */
+.setup-topbar {
+  display: flex;
+  align-items: center;
+  padding: max(env(safe-area-inset-top), 8px) 12px 0 12px;
+}
+.setup-page .hub-hero {
+  padding-top: 8px;
+  padding-bottom: 12px;
+}
+.setup-page .hub-logo {
+  font-size: clamp(1.85rem, 8vw, 2.75rem);
+}
+/* no sticky app-head on setup — dock pins under the safe area only */
+.setup-page #dock.main-nav-parent {
+  position: sticky;
+  top: env(safe-area-inset-top, 0px);
+}
+/* weather / knowledge graph / language / restart — standard page margins */
+.setup-page .setup-section.card,
+.setup-page #section-weather,
+.setup-page #section-kg,
+.setup-page #section-language,
+.setup-page #section-restart {
+  margin: 16px 12px 24px 12px;
+  padding: 18px 16px 22px 16px;
+  box-sizing: border-box;
+  max-width: none;
+}
+.setup-page .setup-section.card > h2:first-child,
+.setup-page .setup-section > h2:first-child {
+  margin-top: 0;
+}
+.setup-page .setup-section form,
+.setup-page .setup-section > div {
+  text-align: left;
+}
+.setup-page .setup-section input[type="text"],
+.setup-page .setup-section input.tinput,
+.setup-page .setup-section select,
+.setup-page .setup-section textarea {
+  width: 100%;
+  max-width: 100%;
+  margin: 6px 0 10px 0;
+}
+.setup-page .setup-section button {
+  margin-top: 10px;
+  margin-bottom: 4px;
+}
+@media (min-width: 700px) {
+  .setup-page .setup-section.card,
+  .setup-page #section-weather,
+  .setup-page #section-kg,
+  .setup-page #section-language,
+  .setup-page #section-restart {
+    margin-left: 16px;
+    margin-right: 16px;
+    padding: 20px 20px 24px 20px;
+  }
+  .setup-page .setup-section form {
+    max-width: 480px;
   }
 }
 
+/* ---------- robots primary panel (discoverable configure path) ---------- */
+.robots-panel {
+  margin-top: 8px;
+}
+.robots-panel-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+.robots-panel-head h2 {
+  margin: 0 0 4px;
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--ink);
+}
+.robots-hint {
+  margin: 0;
+  max-width: none;
+  white-space: normal;
+}
+/* desktop wide: keep the configure hint on a single line */
+@media (min-width: 700px) {
+  .robots-panel-head { align-items: center; }
+  .robots-hint {
+    white-space: nowrap;
+  }
+}
+.robots-all-link {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 36px;
+  padding: 6px 10px;
+  border-radius: 10px;
+  border: 1px solid var(--line);
+  background: var(--panel-2);
+  color: var(--fg-color);
+  text-decoration: none;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+.robots-all-link:hover {
+  border-color: var(--fg-color);
+  color: var(--fg-color);
+}
+/* hub #botStats is a full-width robot card strip (not header chips) */
+.robots-panel #botStats,
+.robots-panel .robots-stats {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  justify-content: center;
+  gap: 12px;
+  height: auto;
+  max-width: none;
+  width: 100%;
+  position: relative;
+}
+.robots-panel #botStats .batteryContainer {
+  flex: 1 1 148px;
+  max-width: 200px;
+  min-height: 120px;
+  height: auto;
+  margin: 0;
+  padding: 14px 12px 12px;
+  gap: 10px;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  background: var(--panel-2);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  cursor: pointer;
+  transition: border-color .15s ease, box-shadow .15s ease, transform .12s ease;
+}
+.robots-panel #botStats .batteryContainer:hover,
+.robots-panel #botStats .batteryContainer:focus-visible {
+  border-color: var(--fg-color);
+  box-shadow: 0 0 0 1px rgba(53, 224, 207, .35), 0 8px 24px rgba(0, 0, 0, .35);
+  outline: none;
+}
+.robots-panel #botStats .batteryContainer:active {
+  transform: scale(.98);
+}
+.robots-panel #botStats .vectorFace {
+  width: 52px;
+  height: 52px;
+  flex: 0 0 auto;
+  order: -1;
+}
+.robots-panel #botStats .batteryOutline {
+  width: 72px;
+  height: 26px;
+  border-radius: 5px;
+  outline-width: 2px;
+}
+.robots-panel #botStats .batteryOutline::after {
+  left: 74px;
+  top: 6px;
+  width: 5px;
+  height: 14px;
+}
+.robots-panel #botStats .charging {
+  width: 16px;
+  height: 16px;
+}
+.robots-panel #botStats .tooltip {
+  position: static;
+  display: block;
+  margin: 0;
+  top: auto;
+  right: auto;
+  left: auto;
+  padding: 0;
+  background: transparent;
+  box-shadow: none;
+  border: none;
+  text-align: center;
+  font-size: 11px;
+  color: var(--muted);
+  line-height: 1.35;
+  order: 10;
+}
+.robots-panel #botStats .batteryContainer::after {
+  content: "Configure";
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 28px;
+  margin-top: 2px;
+  padding: 0 12px;
+  border-radius: 999px;
+  background: rgba(53, 224, 207, .12);
+  border: 1px solid rgba(53, 224, 207, .35);
+  color: var(--fg-color);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  order: 20;
+}
+.robots-panel #botStats .botLoader {
+  width: 52px;
+  height: 52px;
+  background-size: 52px 52px;
+  margin: 12px auto;
+}
+
+.robots-empty {
+  text-align: center;
+  padding: 8px 4px 4px;
+}
+.robots-empty p { margin: 0 0 8px; }
+.robots-empty-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+  margin-top: 12px;
+}
+.robots-empty-actions button {
+  width: auto;
+  min-width: 160px;
+}
+.robots-secondary-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: 0 16px;
+  border-radius: 12px;
+  border: 1px solid var(--line);
+  background: var(--panel-2);
+  color: var(--ink);
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.robots-secondary-btn:hover {
+  border-color: var(--fg-color);
+  color: var(--fg-color);
+}
+
+/* Section label above a dock — icons sit indented under the label text */
+.hub-tools-label {
+  margin: 14px 14px 0;
+  padding: 0 2px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+/* dock rail indented to align with the label (hub + setup) */
+#hub-nav.main-nav-parent,
+.setup-page #dock.main-nav-parent {
+  padding-left: 14px;
+  padding-right: 14px;
+  /* keep icon row optically under the label, not full-bleed flush */
+  margin-left: 0;
+  margin-right: 0;
+}
+
+/* ---------- hub tools dock (index.html #hub-nav) ----------
+   Same rail as settings/setup #dock. Alignment/scroll via .dock-fits /
+   .dock-overflow (ui.js) — do not force overflow-x:visible here. */
+#hub-nav.main-nav-parent {
+  /* no sticky app-head on hub — pin under safe area */
+  top: env(safe-area-inset-top, 0px);
+  height: var(--dock-h);
+  gap: 4px;
+  padding: 8px 10px;
+  margin: 0;
+}
+#hub-nav .main-nav-child {
+  flex: 0 0 auto;
+  min-width: 0;
+  max-width: none;
+  width: auto;
+}
+#hub-nav .main-nav-child a {
+  width: auto;
+  min-width: 66px;
+  position: relative;
+}
+@media (min-width: 760px) {
+  #hub-nav .main-nav-child a {
+    min-width: 78px;
+    padding: 6px 10px;
+  }
+}
+
+/* leave room under sticky dock when JS scrolls a section into view */
+.hub-page #section-intents,
+.hub-page #section-botauth,
+.hub-page #section-log,
+.hub-page #section-version,
+.hub-page #section-uicustomizer {
+  scroll-margin-top: calc(var(--dock-h) + 36px);
+}
+
+/* progressive disclosure: when a hub tool section is open, park the
+   robots CTA so Log / Intents / etc. land in-viewport (not under the fold) */
+body.hub-section-open .robots-panel {
+  display: none;
+}
+body.hub-section-open .hub-hero {
+  padding-top: max(env(safe-area-inset-top), 8px);
+  padding-bottom: 4px;
+}
+body.hub-section-open .hub-splash {
+  width: 48px;
+  height: 48px;
+  margin-bottom: 4px;
+}
+body.hub-section-open .hub-logo {
+  font-size: clamp(1.35rem, 5vw, 1.75rem);
+}
+body.hub-section-open .hub-tagline {
+  display: none;
+}
+body.hub-section-open .hub-tools-label {
+  margin-top: 6px;
+}
+/* sticky tools rail while reading a section (scroll offset for scrollIntoView) */
+body.hub-section-open #hub-nav.main-nav-parent {
+  position: sticky;
+  top: env(safe-area-inset-top, 0px);
+  z-index: 39;
+}
+@media (prefers-reduced-motion: reduce) {
+  /* JS still scrolls; CSS has no motion of its own here */
+}
+
+/* foldable section headers on the hub intents card */
+#foldable-add,
+#foldable-edit {
+  cursor: pointer;
+  user-select: none;
+  color: var(--ink);
+  font-size: 16px;
+  padding: 8px 0;
+  margin: 0;
+}
+#foldable-add span,
+#foldable-edit span {
+  color: var(--fg-color);
+  margin-right: 6px;
+  font-weight: 700;
+}
+
+/* ---------- section cards ---------- */
+.toggleable-section {
+  margin: 14px 12px 0 12px;
+  padding: 16px 16px 18px 16px;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  animation: sectionIn .18s ease both;
+}
+@keyframes sectionIn {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: none; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .toggleable-section { animation: none; }
+}
+
+.toggleable-section h2,
+.toggleable-section h3,
+.toggleable-section h4 {
+  margin: 0 0 6px 0;
+  text-align: left;
+}
+.toggleable-section h2 { font-size: 18px; color: var(--ink); }
+.toggleable-section h3 { font-size: 15px; color: var(--ink); }
+.toggleable-section h4 {
+  font-size: 13px;
+  color: var(--muted);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .06em;
+}
+.toggleable-section p { color: var(--muted); font-size: 14px; margin: 6px 0; }
+.toggleable-section hr { border-top: 1px solid var(--line); }
+
+/* generic card shell (control + setup + future pages) */
+.card {
+  margin: 14px 12px 0 12px;
+  padding: 14px 16px 16px 16px;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  animation: sectionIn .18s ease both;
+}
+@media (prefers-reduced-motion: reduce) {
+  .card { animation: none; }
+}
+.card h2 { margin: 0 0 8px 0; font-size: 18px; text-align: left; color: var(--ink); }
+.card h3 { margin: 0 0 6px 0; font-size: 15px; text-align: left; color: var(--ink); }
+.card h4 {
+  margin: 0 0 6px 0;
+  font-size: 13px;
+  color: var(--muted);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .06em;
+  text-align: left;
+}
+.card p { color: var(--muted); font-size: 14px; margin: 6px 0; }
+.card hr { border-top: 1px solid var(--line); }
+.card small.center,
+.card small { display: block; color: var(--muted); font-size: 12.5px; text-align: left; }
+.card .center { text-align: left; }
+/* plain field labels (setup weather/KG forms) — not radio pills / checkboxes */
+.card form > label:not(.checkbox-label):not(.desc),
+.card form span > label:not(.checkbox-label):not(.desc),
+.card form div > label:not(.checkbox-label):not(.desc) {
+  display: block;
+  margin: 10px 0 4px 0;
+  color: var(--ink);
+  font-size: 13.5px;
+  text-align: left;
+}
+.card .checkbox-label {
+  display: inline;
+  padding: 0;
+  margin-left: 5px;
+  background: none;
+  border: none;
+  border-radius: 0;
+  cursor: pointer;
+  font-size: inherit;
+  color: var(--ink);
+}
+/* checkbox rows: keep control + label on one wrap line */
+.card span:has(> input[type="checkbox"]) {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin: 10px 0;
+  text-align: left;
+}
+.card span:has(> input[type="checkbox"]) .checkbox-label {
+  margin-left: 0;
+  flex: 1;
+  word-break: break-word;
+}
+
+.center { text-align: left; }
+
+/* current-value readouts injected by main.js */
+#currentVolume p, #currentEyeColor p, #currentLocale p, #currentTimeSet p,
+#currentTempFormat p, #currentButton p, #currentLocation p, #currentTimeZone p,
+#statsSection p {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12.5px;
+  color: var(--fg-color);
+  letter-spacing: .03em;
+  margin: 4px 0;
+}
+
+/* ---------- radio groups become tap-friendly pills ----------
+   Scoped to labels that *contain* a radio so plain form labels
+   and .checkbox-label rows inside .card (setup.html) stay normal. */
+.toggleable-section label:has(input[type="radio"]),
+.card label:has(input[type="radio"]) {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px 12px 40px;
+  margin: 6px 0;
+  background: var(--panel-2);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  font-size: 14.5px;
+  color: var(--ink);
+  cursor: pointer;
+  transition: border-color .12s ease, background .12s ease;
+}
+.toggleable-section label:has(input[type="radio"]):active,
+.card label:has(input[type="radio"]):active { background: #262c34; }
+.toggleable-section label:has(input[type="radio"]:checked),
+.card label:has(input[type="radio"]:checked) {
+  border-color: var(--fg-color);
+  background: rgba(53, 224, 207, .08);
+}
+/* hide the native radio; keep in DOM for main.js .checked */
+.toggleable-section label input[type="radio"],
+.card label input[type="radio"] {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+  margin: 0;
+  padding: 0;
+  pointer-events: none;
+  appearance: none;
+  -webkit-appearance: none;
+}
+.toggleable-section label:has(input[type="radio"])::before,
+.card label:has(input[type="radio"])::before {
+  content: "";
+  position: absolute;
+  left: 14px;
+  top: 50%;
+  width: 16px;
+  height: 16px;
+  transform: translateY(-50%);
+  border-radius: 50%;
+  border: 2px solid var(--muted);
+  background: transparent;
+  transition: all .12s ease;
+}
+.toggleable-section label:has(input[type="radio"]:checked)::before,
+.card label:has(input[type="radio"]:checked)::before {
+  border-color: var(--fg-color);
+  background: var(--fg-color);
+  box-shadow: inset 0 0 0 3.5px var(--panel-2), 0 0 8px rgba(53, 224, 207, .4);
+}
+.toggleable-section label:has(input[type="radio"]) br,
+.card label:has(input[type="radio"]) br { display: none; }
+.card label:has(input[type="radio"]:disabled) { opacity: .45; }
+
+/* unstyled radios outside pill labels (fallback) */
+input[type='radio'] {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 2px solid var(--muted);
+  background: transparent;
+  cursor: pointer;
+  position: relative;
+  vertical-align: middle;
+  margin: 0 6px 0 0;
+}
+input[type='radio']:checked {
+  border-color: var(--fg-color);
+  background: var(--fg-color);
+  box-shadow: inset 0 0 0 3.5px var(--panel-2);
+}
+input[type='radio']:disabled { cursor: not-allowed; opacity: .45; }
+
+/* ---------- inputs, selects, textarea, buttons ---------- */
+input.tinput,
+select,
+input[type="text"],
+textarea {
+  width: 100%;
+  padding: 12px 14px;
+  background: var(--panel-2);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  color: var(--ink);
+  font-size: 16px; /* prevents iOS zoom */
+  font-family: inherit;
+  margin: 6px 0;
+  appearance: none;
+  box-sizing: border-box;
+  box-shadow: none;
+  text-align: left;
+}
+select {
+  background-image:
+    linear-gradient(45deg, transparent 50%, var(--muted) 50%),
+    linear-gradient(135deg, var(--muted) 50%, transparent 50%);
+  background-position: calc(100% - 20px) 50%, calc(100% - 14px) 50%;
+  background-size: 6px 6px;
+  background-repeat: no-repeat;
+}
+textarea {
+  height: 280px;
+  resize: vertical;
+}
+input[type="file"] {
+  color: var(--muted);
+  margin: 6px 0;
+  max-width: 100%;
+}
+input[type='text']:disabled,
+input.tinput:disabled {
+  cursor: not-allowed;
+  opacity: .55;
+}
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+button:focus-visible,
+a:focus-visible {
+  outline: 2px solid var(--fg-color);
+  outline-offset: 2px;
+}
+
+button,
+button[type="submit"] {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: 10px 18px;
+  margin: 6px 6px 0 0;
+  background: var(--fg-color);
+  color: #06211e;
+  border: none;
+  border-radius: 12px;
+  font-family: inherit;
+  font-size: 14.5px;
+  font-weight: 700;
+  letter-spacing: .02em;
+  cursor: pointer;
+  transition: filter .12s ease, transform .05s ease;
+  width: auto;
+  box-shadow: none;
+}
+button:active,
+button[type="submit"]:active {
+  transform: scale(.97);
+  filter: brightness(.9);
+}
+button:disabled,
+button[type="submit"]:disabled {
+  opacity: .45;
+  cursor: not-allowed;
+  filter: none;
+  transform: none;
+  background: var(--panel-2);
+  color: var(--muted);
+  border: 1px solid var(--line);
+}
+
+/* secondary buttons (delete / rename / refresh) */
+#faceButtons button,
+#section-stats button,
+#section-photos button,
+#section-face .center button,
+#section-alexa button {
+  background: var(--panel-2);
+  color: var(--ink);
+  border: 1px solid var(--line);
+}
+#faceButtons button:first-child {
+  color: #ff7b7b;
+  border-color: rgba(255, 120, 120, .4);
+}
+
+/* quick actions grid */
+#section-actions .center:first-of-type,
+.qa-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+.qa-grid button,
+#section-actions .center:first-of-type button {
+  width: 100%;
+  margin: 0;
+  background: var(--panel-2);
+  color: var(--ink);
+  border: 1px solid var(--line);
+  font-weight: 600;
+}
+
+/* photos grid */
+#photoSection {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 10px;
+  margin-top: 10px;
+}
+#photoSection img {
+  width: 100%;
+  border-radius: 10px;
+  display: block;
+  border: 1px solid var(--line);
+}
+#photoSection button {
+  width: 100%;
+  margin: 6px 0 0 0;
+  background: var(--panel-2);
+  color: #ff7b7b;
+  border: 1px solid var(--line);
+}
+
+/* iro color wheel / stim chart */
+#picker { display: flex; justify-content: center; padding: 8px 0; }
+#stimChart { max-width: 100%; }
+
+/* ---------- typography helpers ---------- */
+h1, h2, h3, h4, small, p, li, label {
+  font-family: inherit;
+  color: var(--ink);
+}
+h1 {
+  font-size: 1.35rem;
+  font-weight: 700;
+  letter-spacing: .02em;
+  text-align: left;
+  color: var(--ink);
+}
+h2, h3 { margin-top: 0; margin-bottom: 0; }
+
+small.desc,
+.desc { color: var(--muted); }
+
+/* foldable sections (index.html) */
+.content { display: none; }
+
+.wrap {
+  overflow: hidden !important;
+  white-space: nowrap !important;
+}
+
+ul, li {
+  list-style-position: inside;
+  margin: 0;
+  padding: 0;
+}
+
+/* ---------- checkboxes (setup / hub) ---------- */
 input[type='checkbox'] {
   appearance: none;
-  width: 25px;
-  height: 25px;
-  background-color: var(--button-color);
-  border: 2px solid var(--fg-color); /* accent color */
-  border-radius: 5px;
+  -webkit-appearance: none;
+  width: 22px;
+  height: 22px;
+  background-color: var(--panel-2);
+  border: 2px solid var(--line);
+  border-radius: 6px;
   cursor: pointer;
   position: relative;
   display: inline-block;
   vertical-align: middle;
+  flex: 0 0 auto;
 }
-
 input[type='checkbox']:checked {
   background-color: var(--fg-color);
+  border-color: var(--fg-color);
 }
-
 input[type='checkbox']:checked:after {
   content: '';
   position: absolute;
   top: 50%;
   left: 50%;
-  width: 6px;
-  height: 12px;
-  border: solid var(--text-color);
+  width: 5px;
+  height: 10px;
+  border: solid #06211e;
   border-width: 0 2px 2px 0;
   transform: translate(-50%, -60%) rotate(45deg);
 }
@@ -592,4 +1409,125 @@ input[type='checkbox']:checked:after {
   padding-top: 3px;
   margin-left: 5px;
   word-break: break-word;
+  color: var(--ink);
+  display: inline;
+}
+
+/* auth / legacy field widths — keep usable under gold chrome */
+#username, #password {
+  width: 100%;
+  max-width: 499px;
+}
+#botAuth { color: var(--ink); }
+
+/* ---------- desktop hover (fine pointer only) ---------- */
+@media (hover: hover) and (pointer: fine) {
+  .main-nav-child a:hover { background: var(--panel-2); color: var(--ink); }
+  .main-nav-child a:hover i { color: var(--muted); }
+  .main-nav-child a.dock-active:hover i { color: var(--fg-color); }
+  .toggleable-section label:has(input[type="radio"]):hover,
+  .card label:has(input[type="radio"]):hover { border-color: #3a434e; background: #242a32; }
+  .toggleable-section label:has(input[type="radio"]:checked):hover,
+  .card label:has(input[type="radio"]:checked):hover { border-color: var(--fg-color); }
+  button:hover,
+  button[type="submit"]:hover { filter: brightness(1.08); }
+  button:disabled:hover,
+  button[type="submit"]:disabled:hover { filter: none; }
+  .back-btn:hover,
+  .app-head .back-btn:hover {
+    background: var(--panel-2);
+    border-color: #3a434e;
+  }
+}
+
+/* ---------- desktop wide ---------- */
+@media (min-width: 700px) {
+  #content { max-width: 900px; }
+  .app-head h1 { font-size: 18px; }
+  .main-nav-parent {
+    flex-wrap: wrap;
+    height: auto;
+    justify-content: center;
+    overflow-x: visible;
+    padding: 10px 12px;
+  }
+  .main-nav-child a { min-width: 84px; }
+  .toggleable-section,
+  .card {
+    margin: 16px 12px 0 12px;
+    padding: 22px 26px 26px 26px;
+  }
+  .toggleable-section h2,
+  .card h2 { font-size: 20px; }
+
+  /* radio pill groups flow into two columns on wide screens */
+  #section-volume .center:last-of-type,
+  #section-eyes .center:first-of-type,
+  #section-locale .center:last-of-type,
+  #section-time .center:last-of-type,
+  #section-temp .center:last-of-type,
+  #section-button .center:last-of-type {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0 12px;
+  }
+
+  #section-actions .center:first-of-type { grid-template-columns: repeat(3, 1fr); }
+  #photoSection { grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); }
+  input.tinput, select { max-width: 420px; }
+}
+
+/* ---------- short viewports (phone landscape) ----------
+   A rotated phone is "desktop width" but has almost no height —
+   collapse chrome to one slim scrolling row so content wins. */
+@media (max-height: 520px) {
+  :root { --head-h: 42px; --dock-h: 52px; }
+  .app-head { gap: 8px; }
+  .app-head h1 { font-size: 14px; }
+  .app-head .back-btn,
+  .back-btn { width: 32px; height: 32px; border-radius: 10px; font-size: 13px; }
+  #botStats .batteryOutline { width: 46px; height: 18px; }
+  #botStats .batteryOutline::after { left: 48px; top: 4px; height: 10px; }
+  #botStats .charging { width: 14px; height: 14px; }
+  #botStats .vectorFace { width: 28px; height: 28px; }
+
+  .main-nav-parent {
+    flex-wrap: nowrap !important;
+    justify-content: flex-start !important;
+    overflow-x: auto !important;
+    height: var(--dock-h);
+    padding: 6px 8px;
+  }
+  /* hub dock stays a slim horizontal rail in short landscape */
+  #hub-nav.main-nav-parent {
+    height: var(--dock-h);
+    gap: 4px;
+    padding: 6px 8px;
+    flex-wrap: nowrap !important;
+    overflow-x: auto !important;
+  }
+  #hub-nav .main-nav-child {
+    flex: 0 0 auto;
+    min-width: 0;
+    max-width: none;
+  }
+  .main-nav-child a {
+    min-width: 56px;
+    height: 40px;
+    padding: 3px 6px;
+    gap: 2px;
+    font-size: 9px;
+  }
+  .main-nav-child a i { font-size: 13px; }
+  .main-nav-child a.dock-active::after { left: 14px; right: 14px; bottom: 2px; }
+
+  .toggleable-section,
+  .card {
+    margin: 10px 12px 0 12px;
+    padding: 12px 16px 14px 16px;
+  }
+  .toggleable-section h2,
+  .card h2 { font-size: 15px; }
+  .toggleable-section label:has(input[type="radio"]),
+  .card label:has(input[type="radio"]) { padding: 9px 12px 9px 36px; font-size: 13.5px; }
 }

--- a/chipper/webroot/index.html
+++ b/chipper/webroot/index.html
@@ -6,7 +6,7 @@
   <!-- Meta Apple tags for a PWA like experience. -->
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="default">
-  <meta name="theme-color" content="#1e1e1e">
+  <meta name="theme-color" content="#101215">
   <link rel="stylesheet" type="text/css" href="css/style.css" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <script src="https://kit.fontawesome.com/7508f396ac.js" crossorigin="anonymous"></script>
@@ -15,26 +15,56 @@
   <meta http-equiv="Expires" content="Thu, 01 Jan 1970 00:00:00 GMT">
 </head>
 
-<body>
+<body class="hub-page">
   <div id="outer">
     <div id="content" class="">
-      <h1>Wire-Pod</h1>
-      <!-- Bot stats, connected and battery -->
-      <div id="botStats"></div>
-      <hr />
 
-      <div class="main-nav-parent">
+      <!-- Classic Wire-Pod hero / splash (H1Weird + Vector face) -->
+      <header class="hub-hero" aria-label="Wire-Pod">
+        <div class="hub-splash" role="img" aria-label="Vector face"></div>
+        <h1 class="hub-logo">Wire-Pod</h1>
+        <p class="hub-tagline">Local Vector server · setup · bots · tools</p>
+      </header>
+
+      <!-- PRIMARY: robots — parked while a tool section is open (see body.hub-section-open) -->
+      <section class="robots-panel card" aria-labelledby="robots-heading">
+        <div class="robots-panel-head">
+          <div>
+            <h2 id="robots-heading">Your robots</h2>
+            <p class="desc robots-hint">Tap a robot to open configuration — volume, eyes, camera, and more.</p>
+          </div>
+          <a class="robots-all-link" href="/sdkapp">
+            All bots
+            <i class="fa-solid fa-chevron-right" aria-hidden="true"></i>
+          </a>
+        </div>
+        <div id="botStats" class="robots-stats"></div>
+        <div id="botStatsEmpty" class="robots-empty" style="display: none" role="status">
+          <p><strong>No robots connected yet.</strong></p>
+          <p class="desc">Set up a bot over Bluetooth, or open the bot picker if you already authenticated one.</p>
+          <div class="robots-empty-actions">
+            <button type="button" onclick="showBotAuth(); return false;">
+              <i class="fa-solid fa-robot" aria-hidden="true"></i> Set up a bot
+            </button>
+            <a class="robots-secondary-btn" href="/sdkapp">Bot picker</a>
+          </div>
+        </div>
+      </section>
+
+      <!-- Tools: settings-style horizontal dock (one row, scroll if needed) -->
+      <p class="hub-tools-label">Server &amp; tools</p>
+      <div class="main-nav-parent" id="hub-nav" role="navigation" aria-label="Server and tools">
         <!--WP settings-->
         <div class="main-nav-child">
           <a href="setup.html"><i class="fa-solid fa-gear"></i><br />Server Settings</a>
         </div>
-        <!--Bot Settings-->
+        <!--Bot Settings (picker)-->
         <div class="main-nav-child">
-          <a href="/sdkapp"><i class="fa solid fa-toolbox"></i><br />Bot Settings</a>
+          <a href="/sdkapp"><i class="fa-solid fa-toolbox"></i><br />Bot Settings</a>
         </div>
         <!--Bot Setup-->
         <div class="main-nav-child">
-          <a href="#" onclick="showBotAuth(); return false;"><i class="fa solid fa-robot" id="icon-BotAuth"
+          <a href="#" onclick="showBotAuth(); return false;"><i class="fa-solid fa-robot" id="icon-BotAuth"
               name="icon"></i><br />Bot Setup</a>
         </div>
         <!--Custom Intents-->
@@ -58,9 +88,8 @@
               name="icon"></i><br />UI Settings</a>
         </div>
       </div>
-      <hr />
 
-      <div id="section-intents" style="display: none">
+      <div id="section-intents" class="card" style="display: none">
         <h2 id="foldable-add" onclick="toggleSection('content-add', 'content-edit')">
           <span>+</span>
           Add a custom intent
@@ -119,7 +148,7 @@
         </div>
       </div>
 
-      <div id="section-botauth" style="display: none">
+      <div id="section-botauth" class="card" style="display: none">
         <h2>Authentication</h2>
         <hr class="small-hr">
         <div>
@@ -149,7 +178,7 @@
         <hr />
       </div>
 
-      <div id="section-log" style="display: none">
+      <div id="section-log" class="card" style="display: none">
         <h2>Log</h2>
         <hr class="small-hr">
         <div class="center">
@@ -166,7 +195,7 @@
         <hr class="log-hr" />
       </div>
 
-      <div id="section-version" style="display: none">
+      <div id="section-version" class="card" style="display: none">
         <h2>Version</h2>
         <hr class="small-hr">
         <div id="versionDiv">
@@ -183,7 +212,7 @@
         <hr />
       </div>
 
-      <div id="section-uicustomizer" style="display: none">
+      <div id="section-uicustomizer" class="card" style="display: none">
         <h2>UI Customizer</h2>
         <hr class="small-hr">
         <p>Accent Color</p>

--- a/chipper/webroot/initial.html
+++ b/chipper/webroot/initial.html
@@ -2,14 +2,13 @@
 <html>
 
 <head>
-    
   <title>Wire-Pod Initial Setup</title>
   <!-- Meta Apple tags for a PWA like experience. -->
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="default">
-  <meta name="theme-color" content="#1e1e1e">
+  <meta name="theme-color" content="#101215">
   <link rel="stylesheet" type="text/css" href="css/style.css" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <script src="https://kit.fontawesome.com/7508f396ac.js" crossorigin="anonymous"></script>
   <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
   <meta http-equiv="Pragma" content="no-cache">
@@ -18,20 +17,25 @@
 
 <body>
   <div id="outer">
-    <div id="content" class="">
-      <h1>Wire-Pod Setup</h1>
-      <hr />
+    <div id="content">
+
+      <div class="app-head">
+        <h1>Wire-Pod Setup</h1>
+      </div>
+
       <div id="setup-status"></div>
+
       <div id="config-options" style="display: block">
-        <p>
-          Welcome to wire-pod! Configure these
-          options to your liking then click the "Submit Settings" button at the
-          bottom to finish setting up wire-pod.
-        </p>
-        <hr />
-        <div id="section-conn" style="display: block">
-          <h3>Connection Method</h3>
-          <hr class="small-hr">
+        <div class="card">
+          <p>
+            Welcome to wire-pod! Configure these
+            options to your liking then click the "Submit Settings" button at the
+            bottom to finish setting up wire-pod.
+          </p>
+        </div>
+
+        <div class="card" id="section-conn" style="display: block">
+          <h2>Connection Method</h2>
           <div class="center" id="connStatus"></div>
           <select onchange="checkConn()" name="connSelection" id="connSelection">
             <option value="ep">
@@ -42,15 +46,13 @@
             </option>
           </select>
           <div class="center" id="portViz" style="display: none">
-            <label for="portInput">Input custom port here (default is 443)</label>
+            <small class="desc">Input custom port here (default is 443)</small>
             <input type="text" id="portInput" name="portInput" placeholder="443" />
           </div>
-          <hr />
         </div>
 
-        <div id="section-language" style="display: none">
-          <h3>Speech-to-Text Language</h3>
-          <hr class="small-hr">
+        <div class="card" id="section-language" style="display: none">
+          <h2>Speech-to-Text Language</h2>
           <div class="center" id="languageStatus"></div>
           <div id="languageSelectionDiv">
             <select name="languageSelection" id="languageSelection">
@@ -70,17 +72,17 @@
               <option value="vi-VN">VietNamese (VN)</option>
             </select>
           </div>
-          <hr />
         </div>
 
-        <small class="desc">Weather and Knowledge Graph settings can be configured in the Server Settings page once
-          wire-pod is set up.</small>
-        <hr />
-
-        <button onclick="sendSetupInfo()">
-          Submit Settings
-        </button>
+        <div class="card">
+          <small class="desc">Weather and Knowledge Graph settings can be configured in the Server Settings page once
+            wire-pod is set up.</small>
+          <button onclick="sendSetupInfo()">
+            Submit Settings
+          </button>
+        </div>
       </div>
+
     </div>
   </div>
 </body>

--- a/chipper/webroot/js/battery.js
+++ b/chipper/webroot/js/battery.js
@@ -163,9 +163,23 @@ async function renderBatteryInfo(serial, i = 0) {
   // For each robot, we'll create a new div to hold the battery information with a class of "batteryContainer"
   var batteryContainer = document.createElement("div");
   batteryContainer.className = "batteryContainer";
+  // Discoverable robot card: explicit label + keyboard (hub UX)
+  batteryContainer.setAttribute("role", "button");
+  batteryContainer.setAttribute("tabindex", "0");
+  batteryContainer.setAttribute(
+    "aria-label",
+    "Configure robot " + serial
+  );
   botStats.appendChild(batteryContainer);
-  batteryContainer.onclick = function() {
+  var goConfigure = function () {
     window.location.href = "/sdkapp/settings.html?serial=" + serial;
+  };
+  batteryContainer.onclick = goConfigure;
+  batteryContainer.onkeydown = function (e) {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      goConfigure();
+    }
   };
 
   // Create a tooltip for the robot's serial number, with class "tooltip"
@@ -242,9 +256,19 @@ async function renderBatteryInfo(serial, i = 0) {
   }, 3000);
 }
 
+function setBotStatsEmptyVisible(show) {
+  var empty = document.getElementById("botStatsEmpty");
+  if (!empty) return;
+  empty.style.display = show ? "block" : "none";
+}
+
 async function processBotStats() {
   try {
+    if (!botStats) return;
+
     // While loading, set a loading gif in a class div of "botLoader" to the botStats div
+    botStats.style.display = "";
+    setBotStatsEmptyVisible(false);
     var botLoader = document.createElement("div");
     botLoader.className = "botLoader";
     botStats.appendChild(botLoader);
@@ -252,10 +276,14 @@ async function processBotStats() {
     const sdkInfo = await getSDKInfo(); //{"global_guid":"tni1TRsTRTaNSapjo0Y+Sw==","robots":[{"esn":"00603f9b","ip_address":"10.42.0.248","guid":"5RlowyehhT8Qq7wEpF6JsQ==","activated":true},{"esn":"004047ef","ip_address":"10.42.0.175","guid":"ofoJZqLP3cwd9YpvXrdAfw==","activated":true}]}
     
     botLoader.remove();
-    if (!sdkInfo) {
+    if (!sdkInfo || !sdkInfo["robots"] || sdkInfo["robots"].length === 0) {
       botStats.style.display = "none";
+      setBotStatsEmptyVisible(true);
       return;
     }
+
+    setBotStatsEmptyVisible(false);
+    botStats.style.display = "";
 
     for (var i = 0; i < sdkInfo["robots"].length; i++) {
       const serial = sdkInfo["robots"][i]["esn"];
@@ -263,6 +291,8 @@ async function processBotStats() {
       renderBatteryInfo(serial, i);
     }
   } catch {
-    // Do nothing
+    // Show empty guidance when SDK probe fails on hub
+    if (botStats) botStats.style.display = "none";
+    setBotStatsEmptyVisible(true);
   }
 }

--- a/chipper/webroot/js/ble.js
+++ b/chipper/webroot/js/ble.js
@@ -18,6 +18,10 @@ function toggleSections(showSection, icon) {
   sections.forEach((section) => (document.getElementById(section).style.display = "none"));
   document.getElementById(showSection).style.display = "block";
   updateColor(icon);
+  // same hub disclosure + scroll-into-view as main.js toggleVisibility
+  if (typeof onHubSectionShown === "function") {
+    onHubSectionShown(showSection);
+  }
 }
 
 function checkBLECapability() {

--- a/chipper/webroot/js/main.js
+++ b/chipper/webroot/js/main.js
@@ -484,16 +484,20 @@ function closeSection(sectionID) {
 }
 
 function updateColor(id) {
+  // Hub nav active-state: only the chosen icon is "selected".
+  // Previously every icon was given nowselectedicon, and gold CSS
+  // styled nowselectedicon like selectedicon — so all 5 glowed.
   const l_id = id.replace("section", "icon");
   const elements = document.getElementsByName("icon");
 
   elements.forEach((element) => {
-    element.classList.remove("selectedicon");
-    element.classList.add("nowselectedicon");
+    element.classList.remove("selectedicon", "nowselectedicon");
+    element.classList.add("notselectedicon");
   });
 
   const targetElement = document.getElementById(l_id);
-  targetElement.classList.remove("notselectedicon");
+  if (!targetElement) return;
+  targetElement.classList.remove("notselectedicon", "nowselectedicon");
   targetElement.classList.add("selectedicon");
 }
 
@@ -609,8 +613,45 @@ function toggleVisibility(sections, sectionToShow, iconId) {
     GetLog = false;
   }
   sections.forEach((section) => {
-    getE(section).style.display = "none";
+    const el = getE(section);
+    if (el) el.style.display = "none";
   });
-  getE(sectionToShow).style.display = "block";
+  const shown = getE(sectionToShow);
+  if (shown) shown.style.display = "block";
   updateColor(iconId);
+  onHubSectionShown(sectionToShow);
+}
+
+/**
+ * Hub progressive disclosure (index.html):
+ * when a tool section opens, hide the robots CTA so the panel isn't
+ * pushed below the fold, and scroll it into view under the sticky dock.
+ * No-ops on pages without .robots-panel (setup, etc.).
+ */
+function onHubSectionShown(sectionId) {
+  const robots = document.querySelector(".robots-panel");
+  if (!robots) return;
+
+  document.body.classList.add("hub-section-open");
+
+  const shown = getE(sectionId);
+  if (!shown) return;
+
+  const preferReduced =
+    window.matchMedia &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  requestAnimationFrame(() => {
+    const dock = document.getElementById("hub-nav");
+    const label = document.querySelector(".hub-tools-label");
+    let offset = 8;
+    if (dock) offset += dock.getBoundingClientRect().height;
+    if (label) offset += label.getBoundingClientRect().height;
+    const top =
+      shown.getBoundingClientRect().top + window.pageYOffset - offset - 6;
+    window.scrollTo({
+      top: Math.max(0, top),
+      behavior: preferReduced ? "auto" : "smooth",
+    });
+  });
 }

--- a/chipper/webroot/js/ui.js
+++ b/chipper/webroot/js/ui.js
@@ -76,3 +76,96 @@ function loadSettings() {
 // call loadSettings
 loadSettings();
 
+/**
+ * Horizontal dock (#hub-nav / #dock):
+ * - .dock-fits when all tabs fit → CSS centers (setup + hub)
+ * - .dock-overflow when not → flex-start + scroll (center+overflow
+ *   is a classic flex bug that hides the rightmost tabs)
+ * - edge fade classes for swipe affordance
+ * - vertical wheel → horizontal scroll when the rail overflows
+ *   (narrow desktop windows ~428px)
+ */
+function updateDockScrollFade(el) {
+    if (!el) return;
+
+    // Measure with start alignment so scrollWidth is trustworthy
+    var prevLeft = el.scrollLeft;
+    el.classList.add("dock-measuring");
+    el.classList.remove("dock-fits", "dock-overflow");
+    // force reflow
+    void el.offsetWidth;
+
+    var maxScroll = el.scrollWidth - el.clientWidth;
+    var overflow = maxScroll > 2;
+
+    el.classList.remove("dock-measuring");
+    el.classList.toggle("dock-overflow", overflow);
+    el.classList.toggle("dock-fits", !overflow);
+
+    if (!overflow) {
+        el.classList.remove("dock-fade-left", "dock-fade-right");
+        el.scrollLeft = 0;
+        return;
+    }
+
+    // restore scroll position within new max
+    el.scrollLeft = Math.min(prevLeft, Math.max(0, maxScroll));
+    maxScroll = el.scrollWidth - el.clientWidth;
+    var sl = el.scrollLeft;
+    el.classList.toggle("dock-fade-left", sl > 2);
+    el.classList.toggle("dock-fade-right", sl < maxScroll - 2);
+}
+
+function bindDockScrollFades(el) {
+    if (!el || el.dataset.dockFadeBound === "1") return;
+    el.dataset.dockFadeBound = "1";
+
+    var update = function () {
+        updateDockScrollFade(el);
+    };
+
+    el.addEventListener("scroll", update, { passive: true });
+    window.addEventListener("resize", update);
+
+    // Map vertical wheel to horizontal scroll when the rail overflows
+    // (desktop trackpad/mouse users on a narrow window).
+    el.addEventListener(
+        "wheel",
+        function (e) {
+            if (el.scrollWidth <= el.clientWidth + 2) return;
+            // Already horizontal gesture — leave it alone
+            if (Math.abs(e.deltaX) > Math.abs(e.deltaY)) return;
+            if (e.deltaY === 0) return;
+            el.scrollLeft += e.deltaY;
+            e.preventDefault();
+            updateDockScrollFade(el);
+        },
+        { passive: false }
+    );
+
+    if (typeof ResizeObserver !== "undefined") {
+        try {
+            var ro = new ResizeObserver(update);
+            ro.observe(el);
+        } catch (err) {
+            /* ignore */
+        }
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", update);
+    } else {
+        requestAnimationFrame(update);
+    }
+    // icon kit / fonts can change tab widths after first paint
+    setTimeout(update, 300);
+    setTimeout(update, 1000);
+}
+
+function initDockScrollFades() {
+    bindDockScrollFades(document.getElementById("hub-nav"));
+    bindDockScrollFades(document.getElementById("dock"));
+}
+
+initDockScrollFades();
+

--- a/chipper/webroot/sdkapp/control.html
+++ b/chipper/webroot/sdkapp/control.html
@@ -5,107 +5,178 @@
   <title>Vector Web App</title>
   <!-- Meta Apple tags for a PWA like experience. -->
   <meta name="apple-mobile-web-app-capable" content="yes">
-  <meta name="apple-mobile-web-app-status-bar-style" content="default">
-  <meta name="theme-color" content="#1e1e1e">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <meta name="theme-color" content="#101215">
   <link rel="stylesheet" type="text/css" href="../css/style.css" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" type="text/css" href="../css/control.css" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, user-scalable=no" />
   <script src="https://kit.fontawesome.com/7508f396ac.js" crossorigin="anonymous"></script>
   <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="Thu, 01 Jan 1970 00:00:00 GMT">
+
 </head>
 
 <body onload="updateControlButtons()">
   <div id="outer">
     <div id="content">
-      <h1 class="center">Vector control (beta)</h1>
-      <hr />
-      <div class="main-nav-parent">
-        <div class="main-nav-child">
-          <a href="#" onclick="goBackToSettings()"><i class="fa-solid fa-reply"></i><br />Back</a>
+
+      <!-- top bar -->
+      <div class="ctl-head">
+        <a class="back-btn" href="#" onclick="goBackToSettings(); return false;" aria-label="Back to settings"><i class="fa-solid fa-reply"></i></a>
+        <h1>Vector Control</h1>
+        <!-- desktop: keyboard map help (hidden on touch — see control.css .kb-only) -->
+        <button type="button" class="ctl-help kb-only" id="kbHelpBtn"
+          aria-label="Keyboard controls help" aria-haspopup="dialog" aria-controls="kbHelpModal" aria-expanded="false">?</button>
+        <button class="ctl-toggle" id="ctlToggle" onclick="vcToggleControl()" aria-pressed="false">
+          <span class="dot"></span><span id="ctlToggleText">Take control</span>
+        </button>
+      </div>
+
+      <!-- keyboard help dialog (desktop) -->
+      <div id="kbHelpModal" class="kb-help-modal" hidden role="dialog" aria-modal="true" aria-labelledby="kbHelpTitle">
+        <div class="kb-help-backdrop" data-kb-help-close tabindex="-1"></div>
+        <div class="kb-help-panel">
+          <div class="kb-help-head">
+            <h2 id="kbHelpTitle">Keyboard controls</h2>
+            <button type="button" class="kb-help-close" data-kb-help-close aria-label="Close">×</button>
+          </div>
+          <p class="kb-help-lead">Desktop only. Take control first, then set <strong>Keyboard Controls</strong> to <strong>On</strong> in the options below.</p>
+          <ul class="kb-help-map">
+            <li><kbd>W</kbd><kbd>A</kbd><kbd>S</kbd><kbd>D</kbd> <span>Drive (forward / left / back / right)</span></li>
+            <li><kbd>R</kbd> / <kbd>F</kbd> <span>Lift up / down</span></li>
+            <li><kbd>T</kbd> / <kbd>G</kbd> <span>Head up / down</span></li>
+          </ul>
+          <p class="kb-help-note">Click in the Say Text field turns keyboard control off so you can type.</p>
+          <button type="button" class="kb-help-done" data-kb-help-close>Got it</button>
         </div>
       </div>
-      <hr />
 
       <div id="sdkActions">
-        <h2 class="center">Camera Feed</h2>
-        <hr class="small-hr">
-        <div class="center" id="camStream"></div>
-        <div style="text-align: left;" class="center">
-          <label>
-            <input type="radio" name="cam" id="cam" onclick="showCamStream()">Begin Camera Stream<br>
-          </label>
-          <label>
-            <input type="radio" name="cam" id="cam" onclick="stopCamStream()" checked>Stop Camera Stream<br>
-          </label>
-        </div>
-        <hr />
 
-        <h2 class="center">Behavior Control</h2>
-        <hr class="small-hr">
-        <small class="center">You must assume behavior control before performing any action</small>
-        <div style="text-align: left;" class="center">
-          <label>
-            <input type="radio" name="control" id="assume_control"
-              onclick="sendForm('/api-sdk/assume_behavior_control?priority=high'); updateControlButtons();">Assume<br>
-          </label>
-          <label>
-            <input type="radio" name="control" id="release_control"
-              onclick="sendForm('/api-sdk/release_behavior_control'); updateControlButtons();" checked>Release<br>
-          </label>
-        </div>
-        <hr />
+        <!-- ==================== COCKPIT ==================== -->
+        <div id="cockpit">
+          <div class="cam-shell">
+            <div class="cam-idle" id="camIdle">
+              <i class="fa-solid fa-video-slash"></i>
+              <span>Camera off</span>
+            </div>
+            <div class="center" id="camStream"></div>
+            <div class="cam-hud">
+              <button class="hud-btn" id="camToggle" onclick="vcToggleCam()"><i class="fa-solid fa-video"></i><span id="camToggleText">Camera</span></button>
+              <button class="hud-btn" id="ctlToggleHud" onclick="vcToggleControl()"><i class="fa-solid fa-power-off"></i><span id="ctlToggleHudText">Take control</span></button>
+              <button class="hud-btn" onclick="vcFullscreen()" aria-label="Fullscreen"><i class="fa-solid fa-expand"></i></button>
+            </div>
+            <div id="ctlHint">Take control first</div>
+          </div>
 
-        <h2 class="center">Move Motors</h2>
-        <hr class="small-hr">
-        <small class="center">Toggle Keyboard Controls (unstable) <br> WASD for wheels, R-lift up, F-lift down, T-head
-          up, G-head down</small>
-        <div style="text-align: left;" class="center">
-          <label>
-            <input type="radio" name="keycontrol" id="key_control_on" onclick="toggleKeyboard()" disabled>On<br>
-          </label>
-          <label>
-            <input type="radio" name="keycontrol" id="key_control_off" onclick="toggleKeyboard()" checked
-              disabled>Off<br>
-          </label>
-        </div>
-        <hr />
+          <!-- controller deck: D-pad left, lift/head paddles right -->
+          <div class="deck">
+            <div class="deck-col left">
+              <div id="dpad" aria-label="Drive pad">
+                <i class="arrow a-N fa-solid fa-caret-up" style="--r:0deg"></i>
+                <i class="arrow a-E fa-solid fa-caret-up" style="--r:90deg"></i>
+                <i class="arrow a-S fa-solid fa-caret-up" style="--r:180deg"></i>
+                <i class="arrow a-W fa-solid fa-caret-up" style="--r:270deg"></i>
+                <div class="nub"></div>
+              </div>
+              <div class="deck-label">Drive</div>
+            </div>
 
-        <h2 class="center">Mirror Mode</h2>
-        <hr class="small-hr">
-        <div style="text-align: left;" class="center">
-          <label>
-            <input type="radio" name="mirror" id="mirror_on" onclick="sendForm('/api-sdk/mirror_mode?enable=true')"
-              disabled>On<br>
-          </label>
-          <label>
-            <input type="radio" name="mirror" id="mirror_off" onclick="sendForm('/api-sdk/mirror_mode?enable=false')"
-              checked disabled>Off<br>
-          </label>
+            <div class="deck-col right">
+              <div id="paddles">
+                <button class="pad-btn p-headup" data-act="headup" aria-label="Head up">
+                  <i class="fa-solid fa-angles-up"></i><small>Head</small>
+                </button>
+                <button class="pad-btn p-liftup" data-act="liftup" aria-label="Lift up">
+                  <i class="fa-solid fa-up-long"></i><small>Lift</small>
+                </button>
+                <button class="pad-btn p-headdown" data-act="headdown" aria-label="Head down">
+                  <i class="fa-solid fa-angles-down"></i><small>Head</small>
+                </button>
+                <button class="pad-btn p-liftdown" data-act="liftdown" aria-label="Lift down">
+                  <i class="fa-solid fa-down-long"></i><small>Lift</small>
+                </button>
+              </div>
+              <div class="deck-label">Head &amp; Lift</div>
+            </div>
+          </div>
         </div>
-        <hr />
 
-        <h2 class="center">Say Text</h2>
-        <div class="center">
-          <input class="tinput" name="textSay" id="textSay" type="text" placeholder="Put text here" disabled />
+        <!-- ==================== SAY TEXT ==================== -->
+        <div class="card" id="sayTextCard">
+          <h2>Say Text</h2>
+          <p class="ctl-field-hint" id="sayControlHint" role="status">
+            <i class="fa-solid fa-lock" aria-hidden="true"></i>
+            Take control must be enabled to use Say Text
+          </p>
+          <div class="center say-field-wrap" id="sayFieldWrap">
+            <input class="tinput" name="textSay" id="textSay" type="text"
+              placeholder="What should Vector say?" disabled
+              aria-describedby="sayControlHint"
+              title="Take control must be enabled" />
+          </div>
+          <button type="button" id="saySpeakBtn" onclick="vcSayText()">Speak</button>
         </div>
-        <button onclick="sayText()" type="submit">Submit</button>
-      <hr />
-      <h2 class="center">Play Audio</h2>
-        <div class="center">
-          <input type="file" id="fileInput" accept=".wav">
+
+        <!-- ==================== PLAY AUDIO ==================== -->
+        <div class="card">
+          <h2>Play Audio</h2>
+          <small>Upload a .wav file for Vector to play.</small>
+          <div class="center">
+            <input type="file" id="fileInput" accept=".wav">
+          </div>
+          <button id="uploadButton" style="display: none;" type="submit">Send Audio</button>
+          <div class="center">
+            <audio id="audioOutput" controls></audio>
+          </div>
         </div>
-        <button id="uploadButton" style="display: none;" type="submit">Send Audio</button>
-        <div div class="center">
-          <audio id="audioOutput" controls></audio>
+
+        <!-- ==================== OPTIONS ==================== -->
+        <div class="card">
+          <h2>Mirror Mode</h2>
+          <small>Vector's face becomes his camera feed.</small>
+          <div style="text-align: left;" class="center">
+            <label>
+              <input type="radio" name="mirror" id="mirror_on" onclick="sendForm('/api-sdk/mirror_mode?enable=true')"
+                disabled>On<br>
+            </label>
+            <label>
+              <input type="radio" name="mirror" id="mirror_off" onclick="sendForm('/api-sdk/mirror_mode?enable=false')"
+                checked disabled>Off<br>
+            </label>
+          </div>
         </div>
+
+        <div class="card kb-only">
+          <h2>Keyboard Controls
+            <button type="button" class="kb-help-inline" onclick="document.getElementById('kbHelpBtn').click()"
+              aria-label="Show keyboard map">?</button>
+          </h2>
+          <small>Enable for WASD drive, R/F lift, T/G head. Press <strong>?</strong> in the header for the full map.</small>
+          <div style="text-align: left;" class="center">
+            <label>
+              <input type="radio" name="keycontrol" id="key_control_on" onclick="toggleKeyboard()" disabled>On<br>
+            </label>
+            <label>
+              <input type="radio" name="keycontrol" id="key_control_off" onclick="toggleKeyboard()" checked
+                disabled>Off<br>
+            </label>
+          </div>
+          <div id="keysKey" style="display:none;">
+            W A S D — drive &nbsp;·&nbsp; R / F — lift up / down &nbsp;·&nbsp; T / G — head up / down
+          </div>
+        </div>
+
+        <!-- hidden legacy radios: control.js's updateControlButtons() reads
+             these; the header toggle drives them. Do not remove. -->
+        <div style="display:none;">
+          <input type="radio" name="control" id="assume_control">
+          <input type="radio" name="control" id="release_control" checked>
+        </div>
+
       </div>
-      <hr />
     </div>
-    </div>
-  </div>
-  <hr>
-  </div>
   </div>
 
   <script src="./js/httprequest.js"></script>
@@ -113,6 +184,317 @@
   <script src="./js/control.js"></script>
   <script src="../js/ui.js"></script>
   <script src="../js/play_audio.js"></script>
+
+  <script>
+    /* ------------------------------------------------------------
+       Touch cockpit layer — additive, zero rewiring.
+       Uses sendForm() from control.js, so every request hits the
+       exact same /api-sdk endpoints with the same wheel speeds.
+       ------------------------------------------------------------ */
+    (function () {
+      var controlActive = false;
+      var camActive = false;
+
+      /* ---------- fix control.js's stopCamStream crash ----------
+         Stock version calls removeChild unconditionally; if the stream
+         was never started it throws (see console: NotFoundError in
+         onbeforeunload), which aborts BEFORE the stop_cam_stream
+         request is sent — so the server keeps the stream open and the
+         next page load can't get the camera. This safe replacement is
+         picked up by control.js's own onbeforeunload at call time. */
+      window.stopCamStream = function () {
+        try { stream.src = ""; } catch (e) { }
+        try {
+          if (typeof stream !== "undefined" && stream && stream.parentNode) {
+            stream.parentNode.removeChild(stream);
+          }
+        } catch (e) { }
+        sendForm("/api-sdk/stop_cam_stream");
+      };
+
+      /* if the MJPEG stream drops or fails to start, reset the HUD so
+         the person can just tap Camera again */
+      if (typeof stream !== "undefined" && stream) {
+        stream.addEventListener("error", function () {
+          if (!camActive) return;
+          camActive = false;
+          try { window.stopCamStream(); } catch (e) { }
+          document.getElementById("camIdle").style.display = "flex";
+          document.getElementById("camToggle").classList.remove("rec");
+          document.getElementById("camToggleText").textContent = "Camera";
+        });
+      }
+
+      /* ---------- behavior control master toggle ---------- */
+      function dropFocus() {
+        if (document.activeElement && document.activeElement.blur) document.activeElement.blur();
+      }
+
+      window.vcToggleControl = function () {
+        controlActive = !controlActive;
+        if (controlActive) {
+          document.getElementById("assume_control").checked = true;
+          sendForm('/api-sdk/assume_behavior_control?priority=high');
+        } else {
+          document.getElementById("release_control").checked = true;
+          sendForm('/api-sdk/release_behavior_control');
+        }
+        updateControlButtons();
+        syncToggleUI();
+        dropFocus();
+      };
+
+      function syncToggleUI() {
+        var t = document.getElementById("ctlToggle");
+        t.classList.toggle("on", controlActive);
+        t.setAttribute("aria-pressed", controlActive ? "true" : "false");
+        document.getElementById("ctlToggleText").textContent = controlActive ? "Controlling" : "Take control";
+        document.getElementById("ctlToggleHudText").textContent = controlActive ? "Release" : "Take control";
+        document.getElementById("ctlToggleHud").classList.toggle("rec", controlActive);
+
+        // Say Text: persistent hint + tooltip while control is off
+        var sayHint = document.getElementById("sayControlHint");
+        var sayInput = document.getElementById("textSay");
+        var sayCard = document.getElementById("sayTextCard");
+        var speakBtn = document.getElementById("saySpeakBtn");
+        if (sayHint) {
+          sayHint.hidden = !!controlActive;
+          sayHint.setAttribute("aria-hidden", controlActive ? "true" : "false");
+        }
+        if (sayCard) sayCard.classList.toggle("needs-control", !controlActive);
+        if (sayInput) {
+          sayInput.title = controlActive
+            ? ""
+            : "Take control must be enabled to use Say Text";
+          sayInput.setAttribute(
+            "aria-disabled",
+            controlActive ? "false" : "true"
+          );
+        }
+        if (speakBtn) {
+          speakBtn.title = controlActive
+            ? "Speak the text"
+            : "Take control must be enabled to use Say Text";
+          speakBtn.disabled = !controlActive;
+        }
+      }
+
+      var hintTimer = null;
+      function nudgeControl() {
+        var h = document.getElementById("ctlHint");
+        h.classList.add("show");
+        clearTimeout(hintTimer);
+        hintTimer = setTimeout(function () { h.classList.remove("show"); }, 1600);
+        if (navigator.vibrate) navigator.vibrate([20, 40, 20]);
+        // also pulse the Say Text lock hint if present
+        var sh = document.getElementById("sayControlHint");
+        if (sh && !controlActive) {
+          sh.classList.remove("pulse");
+          void sh.offsetWidth;
+          sh.classList.add("pulse");
+        }
+      }
+
+      /* Speak button / disabled field: explain Take control when locked */
+      window.vcSayText = function () {
+        if (!controlActive) {
+          nudgeControl();
+          return;
+        }
+        if (typeof sayText === "function") sayText();
+      };
+
+      var sayWrap = document.getElementById("sayFieldWrap");
+      if (sayWrap) {
+        sayWrap.addEventListener("pointerdown", function () {
+          if (!controlActive) nudgeControl();
+        });
+      }
+
+      /* ---------- camera toggle (wraps control.js helpers) ---------- */
+      window.vcToggleCam = function () {
+        if (!camActive) {
+          camActive = true;
+          showCamStream();
+        } else {
+          camActive = false;
+          try { stopCamStream(); } catch (e) { }
+        }
+        document.getElementById("camIdle").style.display = camActive ? "none" : "flex";
+        document.getElementById("camToggle").classList.toggle("rec", camActive);
+        document.getElementById("camToggleText").textContent = camActive ? "Live" : "Camera";
+        dropFocus();
+      };
+
+      window.vcFullscreen = function () {
+        var el = document.documentElement;
+        if (!document.fullscreenElement) {
+          (el.requestFullscreen || el.webkitRequestFullscreen || function(){}).call(el);
+        } else {
+          (document.exitFullscreen || document.webkitExitFullscreen || function(){}).call(document);
+        }
+      };
+
+      /* ---------- 8-way drive pad ----------
+         Wheel speeds copied 1:1 from control.js keyboard mapping. */
+      var SPEEDS = {
+        N:  "lw=140&rw=140",    /* w   */
+        NE: "lw=190&rw=100",    /* w+d */
+        E:  "lw=150&rw=-150",   /* d   */
+        SE: "lw=-190&rw=100",   /* s+d */
+        S:  "lw=-150&rw=-150",  /* s   */
+        SW: "lw=-100&rw=190",   /* s+a */
+        W:  "lw=-150&rw=150",   /* a   */
+        NW: "lw=100&rw=190"     /* w+a */
+      };
+      var SECTORS = ["E", "SE", "S", "SW", "W", "NW", "N", "NE"];
+
+      var dpad = document.getElementById("dpad");
+      var currentDir = null;
+      var padPointer = null;
+
+      function dirFromEvent(e) {
+        var r = dpad.getBoundingClientRect();
+        var cx = r.left + r.width / 2, cy = r.top + r.height / 2;
+        var dx = e.clientX - cx, dy = e.clientY - cy;
+        var dist = Math.sqrt(dx * dx + dy * dy);
+        if (dist < r.width * 0.14) return null; /* deadzone */
+        var ang = Math.atan2(dy, dx) * 180 / Math.PI; /* -180..180, 0 = east */
+        var idx = Math.round(ang / 45);
+        if (idx < 0) idx += 8;
+        return SECTORS[idx % 8];
+      }
+
+      function setDir(dir) {
+        if (dir === currentDir) return;
+        currentDir = dir;
+        dpad.className = dir ? ("active d-" + dir) : "";
+        if (dir) {
+          sendForm("/api-sdk/move_wheels?" + SPEEDS[dir]);
+          if (navigator.vibrate) navigator.vibrate(8);
+        } else {
+          /* double stop, same as control.js */
+          sendForm("/api-sdk/move_wheels?lw=0&rw=0");
+          sendForm("/api-sdk/move_wheels?lw=0&rw=0");
+        }
+      }
+
+      dpad.addEventListener("pointerdown", function (e) {
+        e.preventDefault();
+        if (!controlActive) { nudgeControl(); return; }
+        padPointer = e.pointerId;
+        dpad.setPointerCapture(e.pointerId);
+        setDir(dirFromEvent(e));
+      });
+      dpad.addEventListener("pointermove", function (e) {
+        if (e.pointerId !== padPointer) return;
+        e.preventDefault();
+        setDir(dirFromEvent(e));
+      });
+      function padRelease(e) {
+        if (e.pointerId !== padPointer) return;
+        padPointer = null;
+        setDir(null);
+      }
+      dpad.addEventListener("pointerup", padRelease);
+      dpad.addEventListener("pointercancel", padRelease);
+      dpad.addEventListener("contextmenu", function (e) { e.preventDefault(); });
+
+      /* safety: any surprise (tab hidden, etc.) → full stop */
+      document.addEventListener("visibilitychange", function () {
+        if (document.hidden && controlActive) {
+          setDir(null);
+          sendForm("/api-sdk/move_lift?speed=0");
+          sendForm("/api-sdk/move_head?speed=0");
+        }
+      });
+
+      /* ---------- hold-to-move lift & head paddles ---------- */
+      var ACTS = {
+        headup:   { start: "/api-sdk/move_head?speed=2",  stop: "/api-sdk/move_head?speed=0" },
+        headdown: { start: "/api-sdk/move_head?speed=-2", stop: "/api-sdk/move_head?speed=0" },
+        liftup:   { start: "/api-sdk/move_lift?speed=2",  stop: "/api-sdk/move_lift?speed=0" },
+        liftdown: { start: "/api-sdk/move_lift?speed=-2", stop: "/api-sdk/move_lift?speed=0" }
+      };
+
+      document.querySelectorAll(".pad-btn").forEach(function (btn) {
+        var act = ACTS[btn.dataset.act];
+        var held = false;
+
+        function start(e) {
+          e.preventDefault();
+          if (!controlActive) { nudgeControl(); return; }
+          if (held) return;
+          held = true;
+          btn.classList.add("held");
+          btn.setPointerCapture(e.pointerId);
+          sendForm(act.start);
+          if (navigator.vibrate) navigator.vibrate(8);
+        }
+        function stop(e) {
+          if (!held) return;
+          held = false;
+          btn.classList.remove("held");
+          sendForm(act.stop);
+        }
+        btn.addEventListener("pointerdown", start);
+        btn.addEventListener("pointerup", stop);
+        btn.addEventListener("pointercancel", stop);
+        btn.addEventListener("contextmenu", function (e) { e.preventDefault(); });
+      });
+
+      /* release everything when leaving the page (control.js also
+         releases behavior control via its own onbeforeunload) */
+      window.addEventListener("pagehide", function () {
+        if (controlActive) {
+          sendForm("/api-sdk/move_wheels?lw=0&rw=0");
+          sendForm("/api-sdk/move_lift?speed=0");
+          sendForm("/api-sdk/move_head?speed=0");
+        }
+      });
+
+      syncToggleUI();
+    })();
+  </script>
+
+  <script>
+    /* Desktop keyboard-help dialog — additive; does not touch control.js IDs */
+    (function () {
+      var btn = document.getElementById("kbHelpBtn");
+      var modal = document.getElementById("kbHelpModal");
+      if (!btn || !modal) return;
+
+      function openHelp() {
+        modal.hidden = false;
+        btn.setAttribute("aria-expanded", "true");
+        var closeBtn = modal.querySelector(".kb-help-close");
+        if (closeBtn) closeBtn.focus();
+      }
+      function closeHelp() {
+        modal.hidden = true;
+        btn.setAttribute("aria-expanded", "false");
+        btn.focus();
+      }
+
+      btn.addEventListener("click", function (e) {
+        e.preventDefault();
+        if (modal.hidden) openHelp();
+        else closeHelp();
+      });
+      modal.querySelectorAll("[data-kb-help-close]").forEach(function (el) {
+        el.addEventListener("click", function (e) {
+          e.preventDefault();
+          closeHelp();
+        });
+      });
+      document.addEventListener("keydown", function (e) {
+        if (e.key === "Escape" && !modal.hidden) {
+          e.preventDefault();
+          closeHelp();
+        }
+      });
+    })();
+  </script>
 
   <iframe name="hiddenFrame" width="0" height="0" border="0" style="display: none"></iframe>
 </body>

--- a/chipper/webroot/sdkapp/index.html
+++ b/chipper/webroot/sdkapp/index.html
@@ -6,9 +6,9 @@
   <!-- Meta Apple tags for a PWA like experience. -->
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="default">
-  <meta name="theme-color" content="#1e1e1e">
-  <link rel="stylesheet" type="text/css" href="../css/style.css" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="theme-color" content="#101215">
+  <link rel="stylesheet" type="text/css" href="../css/style.css">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <script src="https://kit.fontawesome.com/7508f396ac.js" crossorigin="anonymous"></script>
   <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
   <meta http-equiv="Pragma" content="no-cache">
@@ -18,28 +18,30 @@
 <body>
   <div id="outer">
     <div id="content">
-      <h1 class="center">Vector Configuration</h1>
-      <hr />
-      <div class="main-nav-parent">
-        <div class="main-nav-child">
-          <a href="../index.html"><i class="fa-solid fa-reply"></i><br />Back</a>
-        </div>
+
+      <!-- sticky header: back / title -->
+      <div class="app-head">
+        <a class="back-btn" href="../index.html" aria-label="Back"><i class="fa-solid fa-reply"></i></a>
+        <h1>Vector Configuration</h1>
       </div>
-      <hr />
-      <p>
-        Choose the bot you would like to connect to then press "Connect".
-      </p>
-      <select id="botList" name="botList"></select><br />
-      <button onclick="connectSDK()">Connect</button>
-      <hr />
-      <div id="authResult"></div>
+
+      <div class="card">
+        <p>
+          Choose the bot you would like to connect to then press "Connect".
+        </p>
+        <select id="botList" name="botList"></select>
+        <button onclick="connectSDK()">Connect</button>
+        <div id="authResult"></div>
+      </div>
+
     </div>
   </div>
+
+  <iframe name="hiddenFrame" width="0" height="0" border="0" style="display: none"></iframe>
+  <script src="./js/httprequest.js"></script>
+  <script src="./js/common.js"></script>
+  <script src="../js/ui.js"></script>
+  <script src="./js/auth.js"></script>
 </body>
 
 </html>
-<iframe name="hiddenFrame" width="0" height="0" border="0" style="display: none"></iframe>
-<script src="./js/httprequest.js"></script>
-<script src="./js/common.js"></script>
-<script src="../js/ui.js"></script>
-<script src="./js/auth.js"></script>

--- a/chipper/webroot/sdkapp/settings.html
+++ b/chipper/webroot/sdkapp/settings.html
@@ -6,24 +6,30 @@
   <!-- Meta Apple tags for a PWA like experience. -->
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="default">
-  <meta name="theme-color" content="#1e1e1e">
+  <meta name="theme-color" content="#101215">
   <link rel="stylesheet" type="text/css" href="../css/style.css">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <script src="https://kit.fontawesome.com/7508f396ac.js" crossorigin="anonymous"></script>
   <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="Thu, 01 Jan 1970 00:00:00 GMT">
+
 </head>
 
 <body>
 
   <div id="outer">
     <div id="content" class="">
-      <h1 class="center">Vector Configuration</h1>
-      <div id="botStats"></div>
-      <hr>
-      <div class="main-nav-parent">
-        <div class="main-nav-child"><a href="/sdkapp"><i class="fa-solid fa-reply"></i><br />Back</a></div>
+
+      <!-- sticky header: back / title / live bot telemetry -->
+      <div class="app-head">
+        <a class="back-btn" href="/sdkapp" aria-label="Back"><i class="fa-solid fa-reply"></i></a>
+        <h1>Vector Configuration</h1>
+        <div id="botStats"></div>
+      </div>
+
+      <!-- the dock: sticky scrolling tab rail (was: full-screen icon wall) -->
+      <div class="main-nav-parent" id="dock">
         <div class="main-nav-child"><a href="#" onclick="goToControlPage()"><i
               class="fa-solid fa-gamepad"></i><br />Control<br /></a></div>
         <div class="main-nav-child"><a href="#" onclick="showSection('section-volume'); return false;"><i
@@ -37,7 +43,7 @@
         <div class="main-nav-child"><a href="#" onclick="showSection('section-stim'); return false;"><i
               class="fa-solid fa-face-laugh-beam" id="icon-stim" name="icon"></i><br />Stim</a></div>
         <div class="main-nav-child"><a href="#" onclick="showSection('section-stats'); return false;"><i
-              class="fa-solid fa-chart-simple" id="icon-stim" name="icon"></i><br />Statistics</a></div>
+              class="fa-solid fa-chart-simple" id="icon-stats" name="icon"></i><br />Statistics</a></div>
         <div class="main-nav-child"><a href="#" onclick="showSection('section-photos'); getPhotos(); return false;"><i
               class="fa-solid fa-images" id="icon-photos" name="icon"></i><br />Photos</a></div>
         <div class="main-nav-child"><a href="#" onclick="showSection('section-locale'); return false;"><i
@@ -55,10 +61,9 @@
         <div class="main-nav-child"><a href="#" onclick="showSection('section-timezone'); return false;"><i
               class="fa-solid fa-hourglass" id="icon-timezone" name="icon"></i><br />Time Zone</a></div>
       </div>
-      <hr>
 
       <div id="section-volume" class="toggleable-section" style="display:none;">
-        <h2 class="center">Volume</h2>
+        <h2>Volume</h2>
         <hr class="small-hr">
         <div id="currentVolume" class="center"></div>
         <div style="text-align: left;" class="center">
@@ -84,14 +89,12 @@
             <input type="radio" name="vol" id="High" value="High" onclick="sendForm('/api-sdk/volume?volume=5')">High
           </label>
         </div>
-        <br>
-        <hr>
       </div>
 
       <div id="section-eyes" class="toggleable-section" style="display:none;">
-        <h2 style="margin-bottom: 0px;">Eye Color</h2>
+        <h2>Eye Color</h2>
         <hr class="small-hr">
-        <h4 style="margin-bottom: 0px; margin-top:0px;">Preset Eye Colors:</h4>
+        <h4>Preset Eye Colors</h4>
         <div style="text-align: left;" class="center">
           <label>
             <input type="radio" name="eye" id="Teal" value="Teal"
@@ -122,21 +125,19 @@
               onclick="sendForm('/api-sdk/eye_color?color=6')">Other Green<br>
           </label>
         </div>
-        <br />
         <hr class="small-hr">
-        <h4 style="margin-top: 0px;" class="center">Custom Eye Color:</h4>
-        <div class="center" id="picker"></div><br />
+        <h4>Custom Eye Color</h4>
+        <div class="center" id="picker"></div>
         <div class="center">
-          <button class="settings" onclick="sendCustomColor()">Submit</button>
+          <button class="settings" onclick="sendCustomColor()">Apply custom color</button>
         </div>
-        <hr>
       </div>
 
       <div id="section-face" class="toggleable-section" style="display:none;">
-        <h2 class="center">Face Manager</h2>
+        <h2>Face Manager</h2>
         <hr class="small-hr">
-        <h3 class="center">Modify existing faces:</h3>
-        <p class="center">Choose the face you would like to modify.</p>
+        <h3>Modify existing faces</h3>
+        <p>Choose the face you would like to modify.</p>
         <div class="center">
           <select id="faceList" name="faceList"></select>
         </div>
@@ -150,19 +151,18 @@
           </div>
         </div>
         <hr class="small-hr">
-        <h3 class="center">Add a new face:</h3>
-        <p class="center">Enter a name you'd like to add:</p>
+        <h3>Add a new face</h3>
+        <p>Enter a name you'd like to add:</p>
         <div class="center">
           <input class="tinput" id="faceInput" name="faceInput" type="text" placeholder="Put name here">
         </div>
         <div class="center">
           <button onclick="addFace()">Add Face</button>
         </div>
-        <hr>
       </div>
 
       <div id="section-actions" class="toggleable-section" style="display:none;">
-        <h2 class="center">Quick Actions</h2>
+        <h2>Quick Actions</h2>
         <hr class="small-hr">
         <div class="center">
           <button onclick="sendForm('/api-sdk/cloud_intent?intent=explore_start')">Explore
@@ -177,35 +177,32 @@
             Home</button>
         </div>
         <hr class="small-hr">
-        <h3 class="center">Trigger Hey Vector</h3>
-        <p class="center">Trigger the "Hey Vector" wakeword remotely</p>
-        <p class="center">(Only Dev firmware and 2.0.1.6085ep or later)</p>
+        <h3>Trigger Hey Vector</h3>
+        <p>Trigger the "Hey Vector" wakeword remotely</p>
+        <p><small class="desc">(Only Dev firmware and 2.0.1.6085ep or later)</small></p>
         <div id="heyVectorStatus" class="center"></div>
         <div class="center">
           <button onclick="triggerHeyVector()">Trigger "Hey Vector"</button>
         </div>
-        <hr>
       </div>
 
       <div id="section-stim" class="toggleable-section" style="display:none;">
-        <h2 class="center">Stimulation</h2>
+        <h2>Stimulation</h2>
         <hr class="small-hr">
         <div class="center">
           <canvas id="stimChart"></canvas>
         </div>
-        <hr>
       </div>
 
       <div id="section-stats" class="toggleable-section" style="display:none;">
-        <h2 class="center">Statistics</h2>
+        <h2>Statistics</h2>
         <hr class="small-hr">
-        <button onclick="updateStats()">Refresh</button><br>
+        <button onclick="updateStats()">Refresh</button>
         <div id="statsSection"></div>
-        <hr>
       </div>
 
       <div id="section-photos" class="toggleable-section" style="display:none;">
-        <h2 class="center">Photos</h2>
+        <h2>Photos</h2>
         <hr class="small-hr">
         <div class="center">
           <button onclick="getPhotos()">Refresh List</button>
@@ -213,11 +210,10 @@
         <div class="center">
           <div id="photoSection"></div>
         </div>
-        <hr>
       </div>
 
       <div id="section-locale" class="toggleable-section" style="display:none;">
-        <h2 class="center">Locale</h2>
+        <h2>Locale</h2>
         <hr class="small-hr">
         <div id="currentLocale" class="center"></div>
         <div style="text-align: left;" class="center">
@@ -246,12 +242,10 @@
               onclick="sendForm('/api-sdk/locale?locale=ja-JP')">Japanese<br>
           </label>
         </div>
-        <br>
-        <hr>
       </div>
 
       <div id="section-time" class="toggleable-section" style="display:none;">
-        <h2 class="center">Time Format</h2>
+        <h2>Time Format</h2>
         <hr class="small-hr">
         <div id="currentTimeSet" class="center"></div>
         <div style="text-align: left;" class="center">
@@ -264,12 +258,10 @@
               onclick="sendForm('/api-sdk/time_format_24')">24 Hour<br>
           </label>
         </div>
-        <br>
-        <hr>
       </div>
 
       <div id="section-temp" class="toggleable-section" style="display:none;">
-        <h2 class="center">Temp Format</h2>
+        <h2>Temp Format</h2>
         <hr class="small-hr">
         <div id="currentTempFormat" class="center"></div>
         <div style="text-align: left;" class="center">
@@ -282,12 +274,10 @@
               onclick="sendForm('/api-sdk/temp_f')">Fahrenheit<br>
           </label>
         </div>
-        <br>
-        <hr>
       </div>
 
       <div id="section-button" class="toggleable-section" style="display:none;">
-        <h2 class="center">Button Action</h2>
+        <h2>Button Action</h2>
         <hr class="small-hr">
         <div id="currentButton" class="center"></div>
         <div style="text-align: left;" class="center">
@@ -300,39 +290,35 @@
               onclick="sendForm('/api-sdk/button_alexa')">Alexa<br>
           </label>
         </div>
-        <br>
-        <hr>
       </div>
 
       <div id="section-alexa" class="toggleable-section" style="display:none;">
-        <h2 class="center">Alexa</h2>
+        <h2>Alexa</h2>
         <hr class="small-hr">
         <div id="alexaStatus" class="center"></div>
-        <a class="center" target="_blank" rel="noopener noreferrer"
-          href="https://amazon.com/code">https://amazon.com/code</a>
-        <hr class="small-hr">
+        <p>Get your sign-in code at
+          <a class="center" target="_blank" rel="noopener noreferrer"
+            href="https://amazon.com/code">amazon.com/code</a>
+        </p>
         <div class="center">
           <button onclick="sendForm('/api-sdk/alexa_sign_in')">Signin Alexa</button>
           <button onclick="sendForm('/api-sdk/alexa_sign_out')">Signout Alexa</button>
         </div>
-        <hr>
       </div>
 
       <div id="section-location" class="toggleable-section" style="display:none;">
-        <h2 class="center">Set Location</h2>
+        <h2>Set Location</h2>
         <hr class="small-hr">
         <div id="currentLocation"></div>
         <small class="desc">Example: San Francisco, California</small>
         <div class="center">
           <input class="tinput" id="locationInput" name="locationInput" type="text" placeholder="Put location here">
         </div>
-        <hr class="small-hr">
         <button onclick="sendLocation()">Submit Location</button>
-        <hr>
       </div>
 
       <div id="section-timezone" class="toggleable-section" style="display:none;">
-        <h2 style="margin-bottom:0px;">Set Time Zone</h2>
+        <h2>Set Time Zone</h2>
         <hr class="small-hr">
         <div id="currentTimeZone" class="center"></div>
         <div class="center">
@@ -382,10 +368,7 @@
             <option value="Australia/Auckland">Australia/Auckland</option>
           </select>
         </div>
-        <br />
-        <hr class="small-hr">
         <button onclick="sendTimeZone()">Submit Time Zone</button>
-        <hr>
       </div>
 
     </div>
@@ -401,6 +384,65 @@
   <script src="./js/faces.js"></script>
   <script src="../js/ui.js"></script>
   <script src="./js/heyvector.js"></script>
+
+  <script>
+    /* ------------------------------------------------------------
+       Mobile UX layer (additive — no rewiring of main.js).
+       Wraps showSection so that on tap the section is revealed
+       right under the dock and scrolled into view, and the active
+       dock tab is highlighted + centered in the rail.
+       ------------------------------------------------------------ */
+    (function () {
+      var dock = document.getElementById("dock");
+
+      function markActive(id) {
+        var links = dock.querySelectorAll("a");
+        links.forEach(function (a) { a.classList.remove("dock-active"); });
+        // find the link whose onclick mentions this section id
+        links.forEach(function (a) {
+          var oc = a.getAttribute("onclick") || "";
+          if (oc.indexOf("'" + id + "'") !== -1) {
+            a.classList.add("dock-active");
+            // Only move the rail if the tab isn't fully visible —
+            // a tab the user just tapped is already under their finger,
+            // and yanking the rail around is disorienting.
+            var r = a.getBoundingClientRect();
+            var d = dock.getBoundingClientRect();
+            if (r.left < d.left || r.right > d.right) {
+              var target = dock.scrollLeft + (r.left - d.left) - (d.width - r.width) / 2;
+              dock.scrollTo({ left: Math.max(target, 0), behavior: "smooth" });
+            }
+          }
+        });
+      }
+
+      function revealSection(id) {
+        var el = document.getElementById(id);
+        if (!el) return;
+        // scroll the page so the freshly opened card sits just
+        // below the sticky header + dock — no more "tap into the void"
+        var styles = getComputedStyle(document.documentElement);
+        var offset = 52 + 74 + 8; // header + dock + breathing room
+        var y = el.getBoundingClientRect().top + window.pageYOffset - offset;
+        window.scrollTo({ top: Math.max(y, 0), behavior: "smooth" });
+      }
+
+      if (typeof showSection === "function") {
+        var _showSection = showSection;
+        window.showSection = function (id) {
+          try { _showSection(id); } catch (e) { console.error(e); }
+          markActive(id);
+          revealSection(id);
+        };
+      }
+
+      // open a sensible default so the page never looks empty
+      window.addEventListener("load", function () {
+        try { window.showSection("section-volume"); window.scrollTo(0, 0); } catch (e) { }
+      });
+    })();
+  </script>
+
   <iframe name="hiddenFrame" width="0" height="0" border="0" style="display: none;"></iframe>
 
 </body>

--- a/chipper/webroot/setup.html
+++ b/chipper/webroot/setup.html
@@ -6,42 +6,50 @@
   <!-- Meta Apple tags for a PWA like experience. -->
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="default">
-  <meta name="theme-color" content="#1e1e1e">
+  <meta name="theme-color" content="#101215">
   <link rel="stylesheet" type="text/css" href="css/style.css" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <script src="https://kit.fontawesome.com/7508f396ac.js" crossorigin="anonymous"></script>
   <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="Thu, 01 Jan 1970 00:00:00 GMT">
 </head>
 
-<body>
+<body class="setup-page">
   <div id="outer">
     <div id="content" class="">
-      <h1>Wire-Pod Setup</h1>
-      <hr />
-      <div class="main-nav-parent">
+
+      <!-- Classic hero / splash — Vector face returns home (same as back) -->
+      <div class="setup-topbar">
+        <a class="back-btn" href="index.html" aria-label="Back to Wire-Pod home"><i class="fa-solid fa-reply"></i></a>
+      </div>
+      <header class="hub-hero" aria-label="Wire-Pod Setup">
+        <a href="index.html" class="hub-splash-link" aria-label="Back to Wire-Pod home">
+          <div class="hub-splash" role="img" aria-hidden="true"></div>
+        </a>
+        <h1 class="hub-logo">Wire-Pod Setup</h1>
+      </header>
+
+      <!-- Same pattern as index "Server & tools" + dock icons indented under the label -->
+      <p class="hub-tools-label">Server settings</p>
+      <div class="main-nav-parent" id="dock" role="navigation" aria-label="Server settings">
         <div class="main-nav-child">
-          <a href="index.html"><i class="fa-solid fa-reply"></i><br />Back</a>
-        </div>
-        <div class="main-nav-child">
-          <a href="#" onclick="showWeather(); return false;"><i class="fa solid fa-cloud-sun" id="icon-Weather"
+          <a href="#" onclick="showWeather(); return false;"><i class="fa-solid fa-cloud-sun" id="icon-Weather"
               name="icon"></i><br />Weather</a>
         </div>
         <div class="main-nav-child">
-          <a href="#" onclick="showKG(); return false;"><i class="fa solid fa-diagram-project" id="icon-KG"
+          <a href="#" onclick="showKG(); return false;"><i class="fa-solid fa-diagram-project" id="icon-KG"
               name="icon"></i><br />Knowledge Graph</a>
         </div>
         <div class="main-nav-child">
           <a href="#" onclick="showLanguage(); return false;"><i class="fa-solid fa-language" id="icon-Language"
               name="icon"></i><br />Set Language</a>
         </div>
-        <!--<div class="main-nav-child"><a href="#" onclick="showRestart(); return false;"><i class="fa solid fa-arrow-rotate-right" id="icon-Restart" name="icon"></i><br/>Restart Wire-Pod</a></div> -->
+        <!--<div class="main-nav-child"><a href="#" onclick="showRestart(); return false;"><i class="fa-solid fa-arrow-rotate-right" id="icon-Restart" name="icon"></i><br/>Restart Wire-Pod</a></div> -->
       </div>
-      <hr />
 
-      <div id="section-weather" style="display: none">
-        <h3>Weather API Setup</h3>
+      <div id="section-weather" class="card setup-section" style="display: none">
+        <h2>Weather API Setup</h2>
         <hr class="small-hr">
         <div>
           <p>Set the weather provider you'd like to use.</p>
@@ -66,12 +74,11 @@
             Apply Weather Settings
           </button>
           <div id="addWeatherProviderAPIStatus"></div>
-          <hr />
         </div>
       </div>
 
-      <div id="section-kg" style="display: none">
-        <h3>Knowledge Graph Setup</h3>
+      <div id="section-kg" class="card setup-section" style="display: none">
+        <h2>Knowledge Graph Setup</h2>
         <hr class="small-hr">
         <div>
           <p>Select the knowledge provider you would like to use, then enter the required information.</p>
@@ -189,11 +196,10 @@
         <hr class="small-hr">
         <button onclick="sendKGAPIKey()">Apply Settings</button>
         <div id="addKGProviderAPIStatus"></div>
-        <hr />
       </div>
 
-      <div id="section-restart" style="display: none">
-        <h3>Restart Wire-Pod</h3>
+      <div id="section-restart" class="card setup-section" style="display: none">
+        <h2>Restart Wire-Pod</h2>
         <div>
           <p>
             Restart Wire-Pod to apply the initial setup settings immediately
@@ -203,11 +209,10 @@
             <button onclick="sendRestart()">Restart Wire-Pod</button>
           </div>
           <div id="restartStatus"></div>
-          <hr />
         </div>
       </div>
 
-      <div id="section-language" style="display: none">
+      <div id="section-language" class="card setup-section" style="display: none">
         <h2>STT Language</h2>
         <hr class="small-hr">
         <p>Set the speech-to-text language you'd like wire-pod to use.</p>
@@ -239,8 +244,8 @@
             </button>
           </div>
         </div>
-        <hr />
       </div>
+
     </div>
   </div>
 </body>


### PR DESCRIPTION
## Summary

Drop-in refresh of the wire-pod **webroot UI** so hub, setup, initial, SDK index, settings, and Vector Control share one modern dark theme—**mobile-first**, with a **frameless FPV-style control cockpit** on phone landscape—while remaining a **100% drop-in file replacement** for existing installs.

Visual language and patterns are taken from the already-shipped **control** and **settings** pages and rolled out consistently across the rest of the webroot. No server, API, or robot-behavior changes: replace the webroot files, keep the same paths, IDs, form fields, and handlers.

---

## For users (what you get)

### One consistent look
- Dark shell, teal accents, clearer cards/buttons, sticky headers
- Touch-friendly controls (~44px targets) and safe-area support (notches / home indicators)
- Same flows you already know—just easier on a phone or tablet

### Mobile priority
- Built around phone **portrait and landscape** first, then desktop
- Hub / setup / settings **tool docks** that center when tabs fit, scroll when they don’t, with edge fades so you can tell there’s more to swipe
- Short landscape heights compact the chrome so content still fits

### Vector Control cockpit
- **Portrait:** camera feed + drive D-pad + head/lift paddles, “Take control” toggle, camera HUD
- **Landscape FPV (phone):** **100% frameless** full-screen camera—chrome and option cards hide; translucent **control overlays** sit over the stream (drive left, paddles right)
- **Desktop:** wide camera + control column; keyboard help (`?`) for WASD / lift / head when using a mouse and keyboard
- Clear **Say Text** hints when control isn’t taken yet

### Install / upgrade
- **100% drop-in file compatibility:** replace the existing webroot HTML/CSS/JS assets with this tree
- No config migration, no new endpoints, no renamed form fields or query params
- Existing bookmarks and links (`/`, `/setup.html`, `/sdkapp/settings.html?serial=…`, `/sdkapp/control.html?serial=…`, etc.) keep working

---

## For maintainers (what changed under the hood)

### Drop-in contract (hard guarantee)
| Frozen | Unchanged |
|--------|-----------|
| Routes / page paths | `/`, `index`, `initial`, `setup`, `sdkapp/*` |
| APIs | `/api/*`, `/api-ble/*`, `/api-ssh/*`, `/api-chipper/*`, `/api-sdk/*`, `/cam-stream` |
| DOM contracts | element `id`s, form `name`s, radio ID strings, `onclick` targets |
| Assets | `/assets/*`, existing font faces used by UI settings |

This is a **presentation + CSS architecture** change (plus small shared dock helpers), not a behavior rewrite of control/settings JS.
### CSS architecture
- **`webroot/css/style.css`** — shared design system (tokens, shell, dock, cards, forms, battery, shared responsive)
- **`webroot/css/control.css`** — control cockpit only (camera, D-pad, paddles, HUD, desktop grid, **landscape FPV**); linked **only** from `control.html`
- Large inline styles extracted from control/settings into the shared sheets; legacy **`wing.css` removed**
- Design tokens preserve JS-facing vars (e.g. `--fg-color` for `ui.js` / settings icon rail)

### Product-facing UI work (holistic)
1. **Site-wide visual alignment** — hub, setup, initial, and SDK index match the control/settings look and responsive behavior
2. **Shared dock UX** — fits vs overflow, edge fade, mobile peek, narrow-desktop scroll to last tabs
3. **Hub** — settings-style tool dock, hero/CTA polish, multi-icon active state, collapse robots CTA when a section opens
4. **Setup** — classic Wire-Pod Setup hero, gutters, face → home, labeled server-settings dock
5. **Control cockpit** — touch deck, frameless FPV landscape overlay mode, desktop keyboard help dialog, Say Text lock/hint wiring and layout polish

### Explicit non-goals
- No redesign of robot/SDK **functionality**
- No backend or protocol changes
- No forced dependency upgrades for operators beyond shipping these static files

---

## Test plan

**Smoke (users / manual)**
- [ ] Phone portrait: hub + setup + settings readable; dock usable
- [ ] Phone landscape (short): chrome compact; control enters **frameless FPV** (full-bleed cam + overlay pads)
- [ ] Desktop: control dual-column cockpit; `?` keyboard help; touch-only chrome still fine if window is narrow

** Maintainers**
- [ ] BLE / setup / initial wizards still hit the same endpoints
- [ ] Settings dock + section toggles still driven by existing `settings.js` classes/IDs
- [ ] Control: take control, camera stream, D-pad 8-way, paddles, say text, upload/audio, keyboard controls
- [ ] Drop-in check: copy webroot over a stock tree; open known URLs with `?serial=` without editing Go or config

---

## Notes

Safe visual upgrade for people already running wire-pod: replace files, refresh the browser, same product—better on mobile, and much better as a phone-held FPV controller for Vector.

## Images 

<img width="1400" height="720" alt="wirepod-UI-0" src="https://github.com/user-attachments/assets/ad5fca3e-e401-43bd-959a-9c951f27e1c3" />
<img width="720" height="1400" alt="wirepod-UI-2" src="https://github.com/user-attachments/assets/2e9e4ba8-936b-43f3-a84c-3e0abfbe85d0" />
<details>
<summary>Additional screenshots below: </summary>
<img width="1440" height="2800" alt="wirepod-UI-1" src="https://github.com/user-attachments/assets/d77611e9-c6ef-4f28-a2cd-4eea076e745e" />
<img width="1440" height="2800" alt="wirepod-UI-3" src="https://github.com/user-attachments/assets/5dc2fa57-8eb3-474d-8e5d-fd40368c6301" />
<img width="1440" height="2800" alt="wirepod-UI-4" src="https://github.com/user-attachments/assets/3a8f7b55-036e-4a55-8ff3-b90c2924c96d" />
<img width="1440" height="2800" alt="wirepod-UI-5" src="https://github.com/user-attachments/assets/26f304ce-0266-4a8e-99b3-88b3d3219b81" />
<img width="1280" height="950" alt="wirepod-UI-6-desktop" src="https://github.com/user-attachments/assets/1bb12e60-a959-469a-9833-d648e33831fc" />
<img width="1280" height="950" alt="wirepod-UI-7-desktop" src="https://github.com/user-attachments/assets/d9b145ac-f25c-4373-bb9a-d616582fcfd4" />
<img width="1280" height="950" alt="wirepod-UI-8-desktop" src="https://github.com/user-attachments/assets/ac931421-4506-4220-9bef-578e2e6b95f9" />
</details>