### PR TITLE
Add microphone recording to Play Audio

### DIFF
--- a/chipper/webroot/js/play_audio.js
+++ b/chipper/webroot/js/play_audio.js
@@ -16,6 +16,7 @@ let recMaxTimer = null;
 let recCapturedSamples = 0;
 let recContextClosing = null;
 let recStopping = false;
+let recStarting = false;
 
 const TARGET_RATE = 8000;
 const MAX_REC_SECONDS = 30;
@@ -294,8 +295,22 @@ function recSecondsSoFar() {
   return recCapturedSamples / rate;
 }
 
+function setRecButtons(recording) {
+  const recBtn = document.getElementById("recordButton");
+  const stopBtn = document.getElementById("stopRecordButton");
+  if (recBtn) recBtn.style.display = recording ? "none" : "inline-block";
+  if (stopBtn) stopBtn.style.display = recording ? "inline-block" : "none";
+}
+
+function stopTracks(stream) {
+  if (!stream) return;
+  try {
+    stream.getTracks().forEach((t) => t.stop());
+  } catch (_) {}
+}
+
 async function startRecording() {
-  if (recActive || recStopping) return;
+  if (recActive || recStopping || recStarting) return;
   if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
     alert("Microphone not available in this browser");
     return;
@@ -304,12 +319,15 @@ async function startRecording() {
     alert("No robot serial in URL. Open Vector control from the bot list.");
     return;
   }
-  if (recContextClosing) {
-    try { await recContextClosing; } catch (_) {}
-    recContextClosing = null;
-  }
+  recStarting = true;
+  setRecButtons(true);
+  setStatus("Requesting microphone…");
   try {
-    recStream = await navigator.mediaDevices.getUserMedia({
+    if (recContextClosing) {
+      try { await recContextClosing; } catch (_) {}
+      recContextClosing = null;
+    }
+    const stream = await navigator.mediaDevices.getUserMedia({
       audio: {
         channelCount: 1,
         echoCancellation: true,
@@ -318,6 +336,12 @@ async function startRecording() {
         sampleRate: { ideal: 48000 },
       },
     });
+    if (!recStarting) {
+      stopTracks(stream);
+      return;
+    }
+    stopTracks(recStream);
+    recStream = stream;
 
     // Let the browser pick the hardware rate; requested 48 kHz is only a hint
     // on getUserMedia. Read sampleRate only after the context is running.
@@ -326,6 +350,11 @@ async function startRecording() {
     });
     if (recContext.state === "suspended") {
       await recContext.resume();
+    }
+    if (!recStarting) {
+      stopTracks(stream);
+      cleanupRecGraph();
+      return;
     }
     recSampleRate = recContext.sampleRate;
     recSource = recContext.createMediaStreamSource(recStream);
@@ -363,8 +392,6 @@ async function startRecording() {
       }
     }, MAX_REC_SECONDS * 1000);
 
-    document.getElementById("recordButton").style.display = "none";
-    document.getElementById("stopRecordButton").style.display = "inline-block";
     setStatus(
       "Recording… (" + recSampleRate + " Hz, max " + MAX_REC_SECONDS +
         "s). Speak clearly, then Stop recording, then Send."
@@ -375,6 +402,9 @@ async function startRecording() {
     alert(msg);
     setStatus(msg);
     cleanupRecGraph();
+    setRecButtons(false);
+  } finally {
+    recStarting = false;
   }
 }
 
@@ -418,12 +448,18 @@ function cleanupRecGraph() {
 
 async function stopRecording() {
   if (recStopping) return;
+  if (recStarting && !recActive) {
+    recStarting = false;
+    cleanupRecGraph();
+    setRecButtons(false);
+    setStatus("Recording cancelled");
+    return;
+  }
   recStopping = true;
   if (!recActive && (!recChunks || !recChunks.length)) {
     cleanupRecGraph();
     recStopping = false;
-    document.getElementById("recordButton").style.display = "inline-block";
-    document.getElementById("stopRecordButton").style.display = "none";
+    setRecButtons(false);
     return;
   }
   recActive = false;
@@ -441,8 +477,7 @@ async function stopRecording() {
   recChunks = null;
   recCapturedSamples = 0;
 
-  document.getElementById("recordButton").style.display = "inline-block";
-  document.getElementById("stopRecordButton").style.display = "none";
+  setRecButtons(false);
 
   try {
     if (!mono.length) {

--- a/chipper/webroot/js/play_audio.js
+++ b/chipper/webroot/js/play_audio.js
@@ -12,8 +12,14 @@ let recMute = null;
 let recChunks = null; // array of Float32Array at context sampleRate
 let recSampleRate = 0;
 let recActive = false;
+let recMaxTimer = null;
+let recCapturedSamples = 0;
+let recContextClosing = null;
+let recStopping = false;
 
 const TARGET_RATE = 8000;
+const MAX_REC_SECONDS = 30;
+const FADE_MS = 40;
 
 function getSerial() {
   try {
@@ -70,24 +76,27 @@ function downsampleHQ(input, fromRate, toRate) {
   return output;
 }
 
-/** Soft peak normalize toward target peak (avoid clipping / too quiet) */
+/** Soft peak normalize toward target peak (avoid clipping / too quiet).
+ *  Skip gain when RMS/peak sit at the noise floor so hiss is not boosted. */
 function normalizeSpeech(samples, targetPeak) {
-  targetPeak = targetPeak || 0.85;
+  targetPeak = targetPeak || 0.82;
   let peak = 0;
+  let sumSq = 0;
   for (let i = 0; i < samples.length; i++) {
-    const a = Math.abs(samples[i]);
+    const s = samples[i];
+    const a = Math.abs(s);
     if (a > peak) peak = a;
+    sumSq += s * s;
   }
-  if (peak < 0.001 || peak > 0.99) {
-    // silence or already hot — only scale if quiet
-    if (peak >= 0.001 && peak < 0.2) {
-      const g = Math.min(targetPeak / peak, 4.0);
-      for (let i = 0; i < samples.length; i++) samples[i] *= g;
-    }
+  const rms = samples.length ? Math.sqrt(sumSq / samples.length) : 0;
+  const NOISE_FLOOR_RMS = 0.015;
+  const NOISE_FLOOR_PEAK = 0.04;
+  const MAX_GAIN = 2.5;
+  if (peak < NOISE_FLOOR_PEAK || rms < NOISE_FLOOR_RMS || peak >= targetPeak) {
     return samples;
   }
-  if (peak < targetPeak) {
-    const g = Math.min(targetPeak / peak, 3.5);
+  const g = Math.min(targetPeak / peak, MAX_GAIN);
+  if (g > 1.02) {
     for (let i = 0; i < samples.length; i++) samples[i] *= g;
   }
   return samples;
@@ -159,7 +168,7 @@ function toMonoFromAudioBuffer(audioBuffer) {
 function pcmToVectorWav(floatMono, fromRate) {
   let samples = downsampleHQ(floatMono, fromRate, TARGET_RATE);
   samples = normalizeSpeech(samples, 0.82);
-  applyShortFades(samples, 12, TARGET_RATE);
+  applyShortFades(samples, FADE_MS, TARGET_RATE);
   return floatTo16BitWavBlob(samples, TARGET_RATE);
 }
 
@@ -250,8 +259,43 @@ if (uploadBtn) {
 
 // --- High-quality Record (raw PCM, full session, then convert + auto-send) ---
 
+function micErrorMessage(err) {
+  const name = (err && err.name) || "";
+  if (name === "NotAllowedError" || name === "PermissionDeniedError") {
+    return "Microphone permission was denied. Allow mic access for this site and try again.";
+  }
+  if (name === "NotFoundError" || name === "DevicesNotFoundError") {
+    return "No microphone was found. Plug in a mic and try again.";
+  }
+  if (name === "NotReadableError" || name === "TrackStartError") {
+    return "Microphone is already in use by another application.";
+  }
+  if (name === "OverconstrainedError" || name === "ConstraintNotSatisfiedError") {
+    return "Microphone does not support the requested settings.";
+  }
+  if (name === "SecurityError") {
+    return "Microphone requires a secure (HTTPS) connection.";
+  }
+  if (name === "AbortError") {
+    return "Microphone request was interrupted. Try again.";
+  }
+  return "Could not open microphone: " + ((err && (err.message || err.name)) || "unknown error");
+}
+
+function clearRecMaxTimer() {
+  if (recMaxTimer) {
+    clearTimeout(recMaxTimer);
+    recMaxTimer = null;
+  }
+}
+
+function recSecondsSoFar() {
+  const rate = recSampleRate || 48000;
+  return recCapturedSamples / rate;
+}
+
 async function startRecording() {
-  if (recActive) return;
+  if (recActive || recStopping) return;
   if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
     alert("Microphone not available in this browser");
     return;
@@ -260,6 +304,10 @@ async function startRecording() {
     alert("No robot serial in URL. Open Vector control from the bot list.");
     return;
   }
+  if (recContextClosing) {
+    try { await recContextClosing; } catch (_) {}
+    recContextClosing = null;
+  }
   try {
     recStream = await navigator.mediaDevices.getUserMedia({
       audio: {
@@ -267,13 +315,13 @@ async function startRecording() {
         echoCancellation: true,
         noiseSuppression: true,
         autoGainControl: true,
-        // Prefer highest rate the device allows; we downsample carefully later
         sampleRate: { ideal: 48000 },
       },
     });
 
+    // Let the browser pick the hardware rate; requested 48 kHz is only a hint
+    // on getUserMedia. Read sampleRate only after the context is running.
     recContext = new (window.AudioContext || window.webkitAudioContext)({
-      sampleRate: 48000, // request 48k if browser allows
       latencyHint: "interactive",
     });
     if (recContext.state === "suspended") {
@@ -281,17 +329,24 @@ async function startRecording() {
     }
     recSampleRate = recContext.sampleRate;
     recSource = recContext.createMediaStreamSource(recStream);
-    // Larger buffer = fewer callbacks, less chance of dropouts while recording
     const bufferSize = 4096;
     recProcessor = recContext.createScriptProcessor(bufferSize, 1, 1);
     recChunks = [];
+    recCapturedSamples = 0;
     recActive = true;
 
     recProcessor.onaudioprocess = (e) => {
       if (!recActive) return;
-      const input = e.inputBuffer.getChannelData(0);
-      // copy — input buffer is reused
+      const buf = e.inputBuffer;
+      if (buf && buf.sampleRate) recSampleRate = buf.sampleRate;
+      const input = buf.getChannelData(0);
       recChunks.push(new Float32Array(input));
+      recCapturedSamples += input.length;
+      if (recSecondsSoFar() >= MAX_REC_SECONDS) {
+        recActive = false;
+        setStatus("Reached " + MAX_REC_SECONDS + "s limit — processing…");
+        stopRecording();
+      }
     };
 
     recSource.connect(recProcessor);
@@ -300,21 +355,45 @@ async function startRecording() {
     recProcessor.connect(recMute);
     recMute.connect(recContext.destination);
 
+    clearRecMaxTimer();
+    recMaxTimer = setTimeout(() => {
+      if (recActive) {
+        setStatus("Reached " + MAX_REC_SECONDS + "s limit — processing…");
+        stopRecording();
+      }
+    }, MAX_REC_SECONDS * 1000);
+
     document.getElementById("recordButton").style.display = "none";
     document.getElementById("stopRecordButton").style.display = "inline-block";
     setStatus(
-      "Recording… (" + recSampleRate + " Hz capture). Speak clearly, then Stop recording, then Send."
+      "Recording… (" + recSampleRate + " Hz, max " + MAX_REC_SECONDS +
+        "s). Speak clearly, then Stop recording, then Send."
     );
   } catch (err) {
     console.error(err);
-    alert("Could not open microphone: " + err.message);
-    setStatus("Mic permission denied or unavailable");
+    const msg = micErrorMessage(err);
+    alert(msg);
+    setStatus(msg);
     cleanupRecGraph();
   }
 }
 
+function closeRecContext(ctx) {
+  if (!ctx || ctx.state === "closed") {
+    return Promise.resolve();
+  }
+  try {
+    const p = ctx.close();
+    if (p && typeof p.then === "function") {
+      return p.catch(() => {});
+    }
+  } catch (_) {}
+  return Promise.resolve();
+}
+
 function cleanupRecGraph() {
   recActive = false;
+  clearRecMaxTimer();
   try {
     if (recProcessor) {
       recProcessor.onaudioprocess = null;
@@ -326,41 +405,50 @@ function cleanupRecGraph() {
   try {
     if (recStream) recStream.getTracks().forEach((t) => t.stop());
   } catch (_) {}
-  try { if (recContext) recContext.close(); } catch (_) {}
+  const ctx = recContext;
   recProcessor = null;
   recSource = null;
   recMute = null;
   recStream = null;
   recContext = null;
+  if (ctx && ctx.state !== "closed") {
+    recContextClosing = closeRecContext(ctx);
+  }
 }
 
 async function stopRecording() {
+  if (recStopping) return;
+  recStopping = true;
   if (!recActive && (!recChunks || !recChunks.length)) {
     cleanupRecGraph();
+    recStopping = false;
     document.getElementById("recordButton").style.display = "inline-block";
     document.getElementById("stopRecordButton").style.display = "none";
     return;
   }
   recActive = false;
+  clearRecMaxTimer();
   setStatus("Processing recording…");
 
   // Small delay so last audio buffers flush
   await new Promise((r) => setTimeout(r, 80));
 
-  const rate = recSampleRate || 48000;
+  // Prefer the running context rate (settled after resume / first buffers)
+  const rate = (recContext && recContext.sampleRate) || recSampleRate || 48000;
+  recSampleRate = rate;
   const mono = mergeFloatChunks(recChunks || []);
   cleanupRecGraph();
   recChunks = null;
+  recCapturedSamples = 0;
 
   document.getElementById("recordButton").style.display = "inline-block";
   document.getElementById("stopRecordButton").style.display = "none";
 
-  if (!mono.length) {
-    setStatus("No audio captured");
-    return;
-  }
-
   try {
+    if (!mono.length) {
+      setStatus("No audio captured");
+      return;
+    }
     const blob = pcmToVectorWav(mono, rate);
     // Load into player for optional manual listen — do NOT auto-play
     previewBlob(blob);
@@ -371,6 +459,8 @@ async function stopRecording() {
   } catch (err) {
     console.error(err);
     setStatus("Process failed: " + err.message);
+  } finally {
+    recStopping = false;
   }
 }
 

--- a/chipper/webroot/js/play_audio.js
+++ b/chipper/webroot/js/play_audio.js
@@ -1,148 +1,384 @@
+// Play Audio: file pick or high-quality mic record → 8 kHz mono WAV → /api-sdk/play_sound
+// Recording captures raw PCM (not MediaRecorder/webm) for cleaner speech to Vector.
 
-//Convert the WAV frame rate on the client machine and send the WAV file to be processed at /api-sdk/play_sound
+let processedAudioBlob = null;
 
-let processedAudioBlob = null; 
+// Recording state (raw PCM path)
+let recStream = null;
+let recContext = null;
+let recSource = null;
+let recProcessor = null;
+let recMute = null;
+let recChunks = null; // array of Float32Array at context sampleRate
+let recSampleRate = 0;
+let recActive = false;
 
-document.getElementById('fileInput').addEventListener('change', async () => {
-    const fileInput = document.getElementById('fileInput');
-    if (!fileInput.files.length) {
-        alert('Please, select a WAV file');
-        return;
+const TARGET_RATE = 8000;
+
+function getSerial() {
+  try {
+    if (typeof urlParams !== "undefined" && urlParams && urlParams.get) {
+      return urlParams.get("serial") || "";
     }
+  } catch (_) {}
+  return new URLSearchParams(window.location.search).get("serial") || "";
+}
 
-    const file = fileInput.files[0];
-    const arrayBuffer = await file.arrayBuffer();
-    const audioContext = new (window.AudioContext || window.webkitAudioContext)();
-
-    try {
-        const audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
-
-        let newBuffer;
-
-        //Verify is audio is stereio or mono and convert to mono if necessary
-        if(audioBuffer.numberOfChannels >1){
-            const monoLength = audioBuffer.length;
-            newBuffer = audioContext.createBuffer(1, monoLength, audioBuffer.sampleRate);
-
-            const channelData = newBuffer.getChannelData(0);
-            for (let i = 0; i < monoLength; i++){
-
-                channelData[i] = 0.5 * (audioBuffer.getChannelData(0)[i] + audioBuffer.getChannelData(1)[i]);
-
-                
-            }
-
-        }else{
-            // if already mono, just copy
-            newBuffer = audioBuffer;
-            }
-            
-        
-
-        // adjust frame rate to 8000 Hz
-        const newSampleRate = 8000;
-        const newLength = Math.round(newBuffer.length * newSampleRate / newBuffer.sampleRate);
-        const resampledBuffer  = audioContext.createBuffer(newBuffer.numberOfChannels, newLength, newSampleRate);
-
-        for (let channel = 0; channel < newBuffer.numberOfChannels; channel++) {
-            const oldData = newBuffer.getChannelData(channel);
-            const newData = resampledBuffer .getChannelData(channel);
-
-            for (let i = 0; i < newLength; i++) {
-                const oldIndex = i * newBuffer.sampleRate / newSampleRate;
-                const index0 = Math.floor(oldIndex);
-                const index1 = Math.min(index0 + 1, oldData.length - 1);
-                const fraction = oldIndex - index0;
-
-                newData[i] = oldData[index0] * (1 - fraction) + oldData[index1] * fraction; 
-            }
-        }
-
-        // Create a new WAV file
-        processedAudioBlob = await bufferToWave(resampledBuffer );
-        const url = URL.createObjectURL(processedAudioBlob);
-
-        // play processed audio
-        const audioOutput = document.getElementById('audioOutput');
-        audioOutput.src = url;
-        audioOutput.play();
-
-        // show send button
-        document.getElementById('uploadButton').style.display = 'inline-block';
-    } catch (error) {
-        console.error('Error processing the file:', error);
-    }
-});
-
-function bufferToWave(abuffer) {
-    const numOfChannels = abuffer.numberOfChannels;
-    const length = abuffer.length * numOfChannels * 2 + 44;
-    const buffer = new ArrayBuffer(length);
-    const view = new DataView(buffer);
-    let offset = 0;
-
-    // Escrever cabeçalho WAV
-    setString(view, offset, 'RIFF'); offset += 4;
-    view.setUint32(offset, length - 8, true); offset += 4;
-    setString(view, offset, 'WAVE'); offset += 4;
-    setString(view, offset, 'fmt '); offset += 4;
-    view.setUint32(offset, 16, true); offset += 4; // format size
-    view.setUint16(offset, 1, true); offset += 2; // PCM format
-    view.setUint16(offset, numOfChannels, true); offset += 2; // number of channels
-    view.setUint32(offset, 8000, true); offset += 4; // sample rate
-    view.setUint32(offset, 8000 * numOfChannels * 2, true); offset += 4; // byte rate
-    view.setUint16(offset, numOfChannels * 2, true); offset += 2; // block align
-    view.setUint16(offset, 16, true); offset += 2; // bits per sample
-
-    setString(view, offset, 'data'); offset += 4;
-    view.setUint32(offset, length - offset - 4, true); offset += 4;
-
-    // Copiar os dados de áudio
-    for (let channel = 0; channel < numOfChannels; channel++) {
-        const channelData = abuffer.getChannelData(channel);
-        for (let i = 0; i < channelData.length; i++) {
-            view.setInt16(offset, channelData[i] * 0x7FFF, true);
-            offset += 2;
-        }
-    }
-
-    return new Blob([buffer], { type: 'audio/wav' });
+function setStatus(msg) {
+  const el = document.getElementById("audioStatus");
+  if (el) el.textContent = msg || "";
 }
 
 function setString(view, offset, string) {
-    for (let i = 0; i < string.length; i++) {
-        view.setUint8(offset + i, string.charCodeAt(i));
-    }
+  for (let i = 0; i < string.length; i++) {
+    view.setUint8(offset + i, string.charCodeAt(i));
+  }
 }
 
-document.getElementById('uploadButton').addEventListener('click', async () => {
-    if (!processedAudioBlob) {
-        alert('No processed audio to send.');
-        return;
+/** High-quality downsample: low-pass average box then linear interpolate */
+function downsampleHQ(input, fromRate, toRate) {
+  if (fromRate === toRate) return new Float32Array(input);
+  // Simple anti-alias: average groups when downsampling a lot
+  const ratio = fromRate / toRate;
+  const newLen = Math.max(1, Math.round(input.length / ratio));
+  const output = new Float32Array(newLen);
+
+  if (ratio >= 2) {
+    // Multi-tap average kernel ~ ratio samples
+    const kernel = Math.max(2, Math.floor(ratio));
+    for (let i = 0; i < newLen; i++) {
+      const center = i * ratio;
+      const start = Math.max(0, Math.floor(center - kernel / 2));
+      const end = Math.min(input.length - 1, Math.ceil(center + kernel / 2));
+      let sum = 0;
+      let n = 0;
+      for (let j = start; j <= end; j++) {
+        sum += input[j];
+        n++;
+      }
+      output[i] = n ? sum / n : 0;
     }
+  } else {
+    for (let i = 0; i < newLen; i++) {
+      const pos = i * ratio;
+      const i0 = Math.floor(pos);
+      const i1 = Math.min(i0 + 1, input.length - 1);
+      const f = pos - i0;
+      output[i] = input[i0] * (1 - f) + input[i1] * f;
+    }
+  }
+  return output;
+}
 
-    await uploadAudio(processedAudioBlob);
-});
+/** Soft peak normalize toward target peak (avoid clipping / too quiet) */
+function normalizeSpeech(samples, targetPeak) {
+  targetPeak = targetPeak || 0.85;
+  let peak = 0;
+  for (let i = 0; i < samples.length; i++) {
+    const a = Math.abs(samples[i]);
+    if (a > peak) peak = a;
+  }
+  if (peak < 0.001 || peak > 0.99) {
+    // silence or already hot — only scale if quiet
+    if (peak >= 0.001 && peak < 0.2) {
+      const g = Math.min(targetPeak / peak, 4.0);
+      for (let i = 0; i < samples.length; i++) samples[i] *= g;
+    }
+    return samples;
+  }
+  if (peak < targetPeak) {
+    const g = Math.min(targetPeak / peak, 3.5);
+    for (let i = 0; i < samples.length; i++) samples[i] *= g;
+  }
+  return samples;
+}
 
-async function uploadAudio(blob) {
-    const formData = new FormData();
-    formData.append('sound', blob, 'processed.wav');
+function applyShortFades(samples, fadeMs, rate) {
+  const n = Math.min(Math.floor((fadeMs / 1000) * rate), Math.floor(samples.length / 10));
+  for (let i = 0; i < n; i++) {
+    const g = i / n;
+    samples[i] *= g;
+    samples[samples.length - 1 - i] *= g;
+  }
+}
 
+function floatTo16BitWavBlob(float32, sampleRate) {
+  const numSamples = float32.length;
+  const buffer = new ArrayBuffer(44 + numSamples * 2);
+  const view = new DataView(buffer);
+  let offset = 0;
+  setString(view, offset, "RIFF"); offset += 4;
+  view.setUint32(offset, 36 + numSamples * 2, true); offset += 4;
+  setString(view, offset, "WAVE"); offset += 4;
+  setString(view, offset, "fmt "); offset += 4;
+  view.setUint32(offset, 16, true); offset += 4;
+  view.setUint16(offset, 1, true); offset += 2; // PCM
+  view.setUint16(offset, 1, true); offset += 2; // mono
+  view.setUint32(offset, sampleRate, true); offset += 4;
+  view.setUint32(offset, sampleRate * 2, true); offset += 4;
+  view.setUint16(offset, 2, true); offset += 2;
+  view.setUint16(offset, 16, true); offset += 2;
+  setString(view, offset, "data"); offset += 4;
+  view.setUint32(offset, numSamples * 2, true); offset += 4;
+  for (let i = 0; i < numSamples; i++) {
+    const s = Math.max(-1, Math.min(1, float32[i]));
+    view.setInt16(offset, s < 0 ? s * 0x8000 : s * 0x7fff, true);
+    offset += 2;
+  }
+  return new Blob([buffer], { type: "audio/wav" });
+}
+
+function mergeFloatChunks(chunks) {
+  let total = 0;
+  for (const c of chunks) total += c.length;
+  const out = new Float32Array(total);
+  let o = 0;
+  for (const c of chunks) {
+    out.set(c, o);
+    o += c.length;
+  }
+  return out;
+}
+
+function toMonoFromAudioBuffer(audioBuffer) {
+  const len = audioBuffer.length;
+  const mono = new Float32Array(len);
+  if (audioBuffer.numberOfChannels === 1) {
+    mono.set(audioBuffer.getChannelData(0));
+    return mono;
+  }
+  const ch0 = audioBuffer.getChannelData(0);
+  const ch1 = audioBuffer.getChannelData(1);
+  for (let i = 0; i < len; i++) {
+    mono[i] = 0.5 * (ch0[i] + ch1[i]);
+  }
+  return mono;
+}
+
+/** Full pipeline → Vector-ready 8 kHz mono 16-bit WAV blob */
+function pcmToVectorWav(floatMono, fromRate) {
+  let samples = downsampleHQ(floatMono, fromRate, TARGET_RATE);
+  samples = normalizeSpeech(samples, 0.82);
+  applyShortFades(samples, 12, TARGET_RATE);
+  return floatTo16BitWavBlob(samples, TARGET_RATE);
+}
+
+async function arrayBufferToWirePodWav(arrayBuffer) {
+  const audioContext = new (window.AudioContext || window.webkitAudioContext)();
+  try {
+    const audioBuffer = await audioContext.decodeAudioData(arrayBuffer.slice(0));
+    const mono = toMonoFromAudioBuffer(audioBuffer);
+    return pcmToVectorWav(mono, audioBuffer.sampleRate);
+  } finally {
+    if (audioContext.close) {
+      try { await audioContext.close(); } catch (_) {}
+    }
+  }
+}
+
+function previewBlob(blob) {
+  processedAudioBlob = blob;
+  const url = URL.createObjectURL(blob);
+  const audioOutput = document.getElementById("audioOutput");
+  if (audioOutput) {
+    audioOutput.src = url;
+  }
+  const btn = document.getElementById("uploadButton");
+  if (btn) btn.style.display = "inline-block";
+}
+
+async function uploadAudio(blob, { silent } = {}) {
+  if (!blob) {
+    if (!silent) alert("No audio to send.");
+    return false;
+  }
+  const esn = getSerial();
+  if (!esn) {
+    if (!silent) alert("No robot serial in URL. Open Vector control from the bot list.");
+    return false;
+  }
+  const formData = new FormData();
+  formData.append("sound", blob, "processed.wav");
+  try {
+    const response = await fetch("/api-sdk/play_sound?serial=" + encodeURIComponent(esn), {
+      method: "POST",
+      body: formData,
+    });
+    if (!response.ok) {
+      throw new Error("HTTP " + response.status + " " + response.statusText);
+    }
+    try { await response.json(); } catch (_) {}
+    if (!silent) setStatus("Sent to Vector");
+    return true;
+  } catch (error) {
+    console.error("Error sending audio:", error);
+    if (!silent) setStatus("Send failed: " + error.message);
+    return false;
+  }
+}
+
+// --- File ---
+const fileInputEl = document.getElementById("fileInput");
+if (fileInputEl) {
+  fileInputEl.addEventListener("change", async () => {
+    const fileInput = document.getElementById("fileInput");
+    if (!fileInput.files.length) {
+      alert("Please select an audio file");
+      return;
+    }
+    setStatus("Processing file…");
     try {
-        const dominio = window.location.hostname;
-        esn = urlParams.get("serial");
-        const response = await fetch('/api-sdk/play_sound?serial='+esn, {
-            method: 'POST',
-            body: formData,
-        });
-
-        if (!response.ok) {
-            throw new Error('Erro to send audio: ' + response.statusText);
-        }
-
-        const result = await response.json();
-        console.log('Audio sent successfully:', result);
+      const arrayBuffer = await fileInput.files[0].arrayBuffer();
+      const blob = await arrayBufferToWirePodWav(arrayBuffer);
+      previewBlob(blob);
+      setStatus("Ready — press Send when ready");
     } catch (error) {
-        console.error('Error sending audio:', error);
+      console.error(error);
+      setStatus("Could not process file");
+      alert("Error processing the file: " + error.message);
     }
+  });
 }
+
+const uploadBtn = document.getElementById("uploadButton");
+if (uploadBtn) {
+  uploadBtn.addEventListener("click", async () => {
+    setStatus("Sending…");
+    await uploadAudio(processedAudioBlob);
+  });
+}
+
+// --- High-quality Record (raw PCM, full session, then convert + auto-send) ---
+
+async function startRecording() {
+  if (recActive) return;
+  if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+    alert("Microphone not available in this browser");
+    return;
+  }
+  if (!getSerial()) {
+    alert("No robot serial in URL. Open Vector control from the bot list.");
+    return;
+  }
+  try {
+    recStream = await navigator.mediaDevices.getUserMedia({
+      audio: {
+        channelCount: 1,
+        echoCancellation: true,
+        noiseSuppression: true,
+        autoGainControl: true,
+        // Prefer highest rate the device allows; we downsample carefully later
+        sampleRate: { ideal: 48000 },
+      },
+    });
+
+    recContext = new (window.AudioContext || window.webkitAudioContext)({
+      sampleRate: 48000, // request 48k if browser allows
+      latencyHint: "interactive",
+    });
+    if (recContext.state === "suspended") {
+      await recContext.resume();
+    }
+    recSampleRate = recContext.sampleRate;
+    recSource = recContext.createMediaStreamSource(recStream);
+    // Larger buffer = fewer callbacks, less chance of dropouts while recording
+    const bufferSize = 4096;
+    recProcessor = recContext.createScriptProcessor(bufferSize, 1, 1);
+    recChunks = [];
+    recActive = true;
+
+    recProcessor.onaudioprocess = (e) => {
+      if (!recActive) return;
+      const input = e.inputBuffer.getChannelData(0);
+      // copy — input buffer is reused
+      recChunks.push(new Float32Array(input));
+    };
+
+    recSource.connect(recProcessor);
+    recMute = recContext.createGain();
+    recMute.gain.value = 0;
+    recProcessor.connect(recMute);
+    recMute.connect(recContext.destination);
+
+    document.getElementById("recordButton").style.display = "none";
+    document.getElementById("stopRecordButton").style.display = "inline-block";
+    setStatus(
+      "Recording… (" + recSampleRate + " Hz capture). Speak clearly, then Stop recording, then Send."
+    );
+  } catch (err) {
+    console.error(err);
+    alert("Could not open microphone: " + err.message);
+    setStatus("Mic permission denied or unavailable");
+    cleanupRecGraph();
+  }
+}
+
+function cleanupRecGraph() {
+  recActive = false;
+  try {
+    if (recProcessor) {
+      recProcessor.onaudioprocess = null;
+      recProcessor.disconnect();
+    }
+  } catch (_) {}
+  try { if (recSource) recSource.disconnect(); } catch (_) {}
+  try { if (recMute) recMute.disconnect(); } catch (_) {}
+  try {
+    if (recStream) recStream.getTracks().forEach((t) => t.stop());
+  } catch (_) {}
+  try { if (recContext) recContext.close(); } catch (_) {}
+  recProcessor = null;
+  recSource = null;
+  recMute = null;
+  recStream = null;
+  recContext = null;
+}
+
+async function stopRecording() {
+  if (!recActive && (!recChunks || !recChunks.length)) {
+    cleanupRecGraph();
+    document.getElementById("recordButton").style.display = "inline-block";
+    document.getElementById("stopRecordButton").style.display = "none";
+    return;
+  }
+  recActive = false;
+  setStatus("Processing recording…");
+
+  // Small delay so last audio buffers flush
+  await new Promise((r) => setTimeout(r, 80));
+
+  const rate = recSampleRate || 48000;
+  const mono = mergeFloatChunks(recChunks || []);
+  cleanupRecGraph();
+  recChunks = null;
+
+  document.getElementById("recordButton").style.display = "inline-block";
+  document.getElementById("stopRecordButton").style.display = "none";
+
+  if (!mono.length) {
+    setStatus("No audio captured");
+    return;
+  }
+
+  try {
+    const blob = pcmToVectorWav(mono, rate);
+    // Load into player for optional manual listen — do NOT auto-play
+    previewBlob(blob);
+    const sec = (mono.length / rate).toFixed(1);
+    setStatus(
+      "Recorded " + sec + "s @ " + rate + " Hz → 8 kHz. Press Send when ready."
+    );
+  } catch (err) {
+    console.error(err);
+    setStatus("Process failed: " + err.message);
+  }
+}
+
+const recordBtn = document.getElementById("recordButton");
+const stopRecordBtn = document.getElementById("stopRecordButton");
+if (recordBtn) recordBtn.addEventListener("click", startRecording);
+if (stopRecordBtn) stopRecordBtn.addEventListener("click", stopRecording);
+
+window.addEventListener("beforeunload", () => {
+  try { cleanupRecGraph(); } catch (_) {}
+});

--- a/chipper/webroot/sdkapp/control.html
+++ b/chipper/webroot/sdkapp/control.html
@@ -92,7 +92,7 @@
         <button onclick="sayText()" type="submit">Submit</button>
       <hr />
       <h2 class="center">Play Audio</h2>
-        <small class="center">Choose a file or record (high-quality mic capture → 8 kHz mono for Vector). Assume control first.</small>
+        <small class="center">Choose a file or record (high-quality mic capture → 8 kHz mono for Vector, 30s max). Assume control first.</small>
         <div class="center" style="margin-top:8px;">
           <input type="file" id="fileInput" accept="audio/*,.wav,.mp3,.ogg,.m4a,.webm">
         </div>

--- a/chipper/webroot/sdkapp/control.html
+++ b/chipper/webroot/sdkapp/control.html
@@ -92,11 +92,19 @@
         <button onclick="sayText()" type="submit">Submit</button>
       <hr />
       <h2 class="center">Play Audio</h2>
-        <div class="center">
-          <input type="file" id="fileInput" accept=".wav">
+        <small class="center">Choose a file or record (high-quality mic capture → 8 kHz mono for Vector). Assume control first.</small>
+        <div class="center" style="margin-top:8px;">
+          <input type="file" id="fileInput" accept="audio/*,.wav,.mp3,.ogg,.m4a,.webm">
         </div>
-        <button id="uploadButton" style="display: none;" type="submit">Send Audio</button>
-        <div div class="center">
+        <div class="center" style="margin-top:8px; display:flex; flex-wrap:wrap; gap:8px; justify-content:center;">
+          <button type="button" id="recordButton">Record</button>
+          <button type="button" id="stopRecordButton" style="display:none;">Stop recording</button>
+          <button type="button" id="uploadButton" style="display:none;">Send</button>
+        </div>
+        <div class="center" style="margin-top:6px;">
+          <small id="audioStatus"></small>
+        </div>
+        <div class="center" style="margin-top:8px;">
           <audio id="audioOutput" controls></audio>
         </div>
       </div>


### PR DESCRIPTION
## Summary

The Vector control page's **Play Audio** section only accepted a `.wav` file. This adds a Record / Stop / Send flow so you can capture from the browser microphone and play it on Vector through the existing `/api-sdk/play_sound` endpoint.

Recording uses raw PCM (`ScriptProcessor`) instead of `MediaRecorder`/WebM, then converts to 8 kHz mono 16-bit WAV with a simple anti-alias downsample, light speech normalize, and short fades. File uploads also accept common formats (mp3, ogg, m4a, webm) and go through the same conversion.

Assume behavior control first, same as the rest of the control page.

## Test plan

- [x] Open Vector control, assume behavior control
- [x] Click **Record**, speak, click **Stop recording**, then **Send** — Vector should play the clip
- [x] Confirm the preview player does not auto-play after recording
- [x] Upload a `.wav` file and send (existing path still works)
- [x] Upload an `.mp3` (or other listed format) and send
- [x] Confirm Record without a serial in the URL shows an error
- [x] Confirm Record works after granting mic permission, and is blocked if permission is denied