### PR TITLE
Use MaxCompletionTokens so GPT-5 era models work

### DIFF
--- a/chipper/pkg/wirepod/ttr/kgsim.go
+++ b/chipper/pkg/wirepod/ttr/kgsim.go
@@ -174,14 +174,14 @@ func CreateAIReq(transcribedText, esn string, gpt3tryagain, isKG bool) openai.Ch
 	})
 
 	aireq := openai.ChatCompletionRequest{
-		Model:            model,
-		MaxTokens:        2048,
-		Temperature:      1,
-		TopP:             1,
-		FrequencyPenalty: 0,
-		PresencePenalty:  0,
-		Messages:         nChat,
-		Stream:           true,
+		Model:               model,
+		MaxCompletionTokens: 2048,
+		Temperature:         1,
+		TopP:                1,
+		FrequencyPenalty:    0,
+		PresencePenalty:     0,
+		Messages:            nChat,
+		Stream:              true,
 	}
 	return aireq
 }

--- a/chipper/pkg/wirepod/ttr/kgsim_cmds.go
+++ b/chipper/pkg/wirepod/ttr/kgsim_cmds.go
@@ -486,13 +486,13 @@ func DoGetImage(msgs []openai.ChatCompletionMessage, param string, robot *vector
 	speakReady := make(chan string)
 
 	aireq := openai.ChatCompletionRequest{
-		MaxTokens:        2048,
-		Temperature:      1,
-		TopP:             1,
-		FrequencyPenalty: 0,
-		PresencePenalty:  0,
-		Messages:         msgs,
-		Stream:           true,
+		MaxCompletionTokens: 2048,
+		Temperature:         1,
+		TopP:                1,
+		FrequencyPenalty:    0,
+		PresencePenalty:     0,
+		Messages:            msgs,
+		Stream:              true,
 	}
 	if vars.APIConfig.Knowledge.Provider == "openai" {
 		aireq.Model = openai.GPT4oMini


### PR DESCRIPTION
## Problem

Setting the Knowledge Graph to any current OpenAI model (`gpt-5*`, `o1*`, `o3*`, `o4*`) makes Vector stop answering. There are two distinct failures behind it.

**1. The API rejects `max_tokens`.** GPT-5 era models return:

```
Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.
```

**2. `go-openai` refuses to send the request at all.** This is the confusing one, because it looks like an API error in the log but nothing was ever sent:

```
Using gpt-5.6-luna
Error creating chat completion stream: this model is not supported MaxTokens, please use MaxCompletionTokens
LLM error: this model is not supported MaxTokens, please use MaxCompletionTokens
```

That comes from the client's own validator (`reasoning_validator.go`):

```go
gpt5Series := strings.HasPrefix(request.Model, "gpt-5")
...
if request.MaxTokens > 0 { return ErrReasoningModelMaxTokensDeprecated }
```

Because the check is client-side, it cannot be worked around with a proxy — the model name simply cannot contain a `gpt-5*` string today.

## Fix

Set `MaxCompletionTokens: 2048` instead of `MaxTokens: 2048`. `go-openai` already has the field, and its validator only rejects `MaxTokens > 0`, so both failures go away at once.

Applied at both call sites that build a `ChatCompletionRequest`:

- `chipper/pkg/wirepod/ttr/kgsim.go` — `CreateAIReq`, the main knowledge-graph path
- `chipper/pkg/wirepod/ttr/kgsim_cmds.go` — `DoGetImage`, the vision path

No other `MaxTokens` usage remains in `chipper/pkg`.

## Backward compatibility

`max_completion_tokens` is accepted by older models too, so this is not a break for existing setups. Verified against a real `go-openai` v1.41.2 client (the version in `chipper/go.mod`) using this repo's exact request shape:

| Request shape | Model | Result |
|---|---|---|
| `MaxTokens` (current) | `gpt-5.6-luna` | fails client-side |
| `MaxCompletionTokens` | `gpt-5.6-luna` | works |
| `MaxCompletionTokens` | `gpt-4o-mini` | works |

`Temperature: 1` and `TopP: 1` already satisfy the reasoning-model validator, so no other field needs changing.

`go build` and `go vet` pass on `./pkg/wirepod/ttr/`.
