### PR TITLE
de-DE: short keyphrases like "Hi" match inside longer words and hijack the intent

### DIFF
--- a/chipper/intent-data/de-DE.json
+++ b/chipper/intent-data/de-DE.json
@@ -93,11 +93,13 @@
   },
   {
     "name": "intent_imperative_affirmative",
-    "keyphrases": [ "Ja", "Richtig", "Korrekt", "Wahr", "Stimmt" ]
+    "keyphrases": [ "Ja", "Richtig", "Korrekt", "Wahr", "Stimmt" ],
+    "requiresexact": true
   },
   {
     "name": "intent_imperative_negative",
-    "keyphrases": [ "Nein", "Nicht", "Falsch", "Inkorrekt", "Unwahr", "Stimmt nicht" ]
+    "keyphrases": [ "Nein", "Nicht", "Falsch", "Inkorrekt", "Unwahr", "Stimmt nicht" ],
+    "requiresexact": true
   },
   {
     "name": "intent_photo_take_extend",
@@ -105,11 +107,13 @@
   },
   {
     "name": "intent_imperative_praise",
-    "keyphrases": [ "Gut", "Großartig", "mythisch", "stark", "beeindruckend", "toll", "super", "Guter", "Fantastisch" ]
+    "keyphrases": [ "Gut", "Großartig", "mythisch", "stark", "beeindruckend", "toll", "super", "Guter", "Fantastisch" ],
+    "requiresexact": true
   },
   {
     "name": "intent_imperative_abuse",
-    "keyphrases": [ "Gut", "Großartig", "Mythisch", "Stark", "Beeindruckend", "Toll", "Super", "Guter", "Guter Roboter", "Fantastisch", "Cool", "Klasse" ]
+    "keyphrases": [ "Gut", "Großartig", "Mythisch", "Stark", "Beeindruckend", "Toll", "Super", "Guter", "Guter Roboter", "Fantastisch", "Cool", "Klasse" ],
+    "requiresexact": true
   },
   {
     "name": "intent_imperative_apologize",
@@ -141,7 +145,8 @@
   },
   {
     "name": "intent_greeting_hello",
-    "keyphrases": [ "Hallo", "Wie geht es dir", "Wie geht's", "Wie gehts", "Wie geht's dir", "Wie gehts dir", "Guten Morgen", "Morgen", "Guten Abend", "Abend", "Guten Tag", "Tag", "Hey", "Hallo", "Hi", "Moin" ]
+    "keyphrases": [ "Hallo", "Wie geht es dir", "Wie geht's", "Wie gehts", "Wie geht's dir", "Wie gehts dir", "Guten Morgen", "Morgen", "Guten Abend", "Abend", "Guten Tag", "Tag", "Hey", "Hallo", "Hi", "Moin" ],
+    "requiresexact": true
   },
   {
     "name": "intent_imperative_come",
@@ -205,11 +210,13 @@
   },
   {
     "name": "intent_blackjack_hit",
-    "keyphrases": [ "Hit", "Eine weitere karte", "Noch eine", "Weitere Karte", "Noch eine Karte", "Ja", "Weitere", "Jep" ]
+    "keyphrases": [ "Hit", "Eine weitere karte", "Noch eine", "Weitere Karte", "Noch eine Karte", "Ja", "Weitere", "Jep" ],
+    "requiresexact": true
   },
   {
     "name": "intent_blackjack_stand",
-    "keyphrases": [ "Stand", "Keine mehr", "Das wars", "Das war's", "Keine weiteren Karten", "Nicht weiter", "Nein", "Nicht" ]
+    "keyphrases": [ "Stand", "Keine mehr", "Das wars", "Das war's", "Keine weiteren Karten", "Nicht weiter", "Nein", "Nicht" ],
+    "requiresexact": true
   },
   {
     "name": "intent_play_keepaway",


### PR DESCRIPTION
I run wire-pod with German (de-DE) and noticed that a lot of my questions never
reached the LLM. They got answered as a greeting instead.

Turns out "Hi" is a keyphrase for intent_greeting_hello in de-DE.json, and the
matcher does a plain substring search:

```go
// chipper/pkg/wirepod/ttr/matchIntentSend.go:292
if strings.Contains(voiceText, strings.ToLower(c)) && !b.RequireExactMatch {
```

There are no word boundaries, so "Hi" matches inside "Himmel", "hier", "hilfe",
"hinter" and so on. My log for "warum ist der himmel blau":

```
Bot xxxx Transcribed text: warum ist der himmel blau
Bot xxxx Partial match for intent intent_greeting_hello (hi)
Bot xxxx Intent Sent: intent_greeting_hello
```

The question never made it to the intent graph.

I counted 46 keyphrases in de-DE.json with 5 characters or less. The ones that
bite in normal German are:

* "Hi" matches Himmel, hier, hilfe, hinten
* "Ja" matches Jahr, Jacke, Japan
* "Tag" matches Montag, Vertrag, beantragen
* "Weg" matches wegen, unterwegs, bewegen
* "Stand" matches verstanden, Umstand
* "Gut" is listed for both praise and abuse, which is confusing on its own

I did not want to delete keyphrases, because "ja" and "hallo" on their own are
legitimate commands. Instead I set `"requiresexact": true` on the seven intents
where the keyphrases are short interjections:

* intent_greeting_hello
* intent_imperative_affirmative
* intent_imperative_negative
* intent_imperative_praise
* intent_imperative_abuse
* intent_blackjack_hit
* intent_blackjack_stand

The exact-match pass runs before the substring pass, so saying just "hallo" or
"ja" still works. Only the accidental matches inside longer sentences are gone.

I deliberately did NOT set it on movement or command intents. Those need the
substring search, otherwise "dreh dich um" no longer matches the keyphrase
"Drehe".

After the change, same sentence:

```
Bot xxxx Transcribed text: warum ist der himmel blau
Not a custom intent
Making LLM request for device xxxx...
```

I only touched de-DE.json since that is the one I use. The other language files
probably have the same issue, es-ES has "Si" for example, but I cannot test
those properly so I left them alone.