### PR TITLE
OpenAI Whisper STT: language is forced back to en-US, and language/prompt are never sent to the API

### DIFF
--- a/chipper/pkg/wirepod/preqs/server.go
+++ b/chipper/pkg/wirepod/preqs/server.go
@@ -41,7 +41,7 @@ func ReloadVosk() {
 func New(InitFunc func() error, SttHandler interface{}, voiceProcessor string) (*Server, error) {
 
 	// Decide the TTS language
-	if voiceProcessor != "vosk" && voiceProcessor != "whisper.cpp" {
+	if voiceProcessor != "vosk" && voiceProcessor != "whisper.cpp" && voiceProcessor != "whisper" {
 		vars.APIConfig.STT.Language = "en-US"
 	}
 	sttLanguage = vars.APIConfig.STT.Language

--- a/chipper/pkg/wirepod/stt/whisper/Whisper.go
+++ b/chipper/pkg/wirepod/stt/whisper/Whisper.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-audio/audio"
 	"github.com/go-audio/wav"
 	"github.com/kercre123/wire-pod/chipper/pkg/logger"
+	"github.com/kercre123/wire-pod/chipper/pkg/vars"
 	sr "github.com/kercre123/wire-pod/chipper/pkg/wirepod/speechrequest"
 	"github.com/orcaman/writerseeker"
 )
@@ -76,12 +77,42 @@ func newAudioIntBuffer(r io.Reader) (*audio.IntBuffer, error) {
 	}
 }
 
+// buildVocabPrompt builds a vocabulary hint from the loaded intents. whisper-1
+// accepts a prompt to bias transcription towards expected wording, which helps a
+// lot with command phrases in languages other than English.
+func buildVocabPrompt() string {
+	var sb strings.Builder
+	for _, in := range vars.IntentList {
+		for _, kp := range in.Keyphrases {
+			k := strings.TrimSpace(kp)
+			if len(k) < 4 {
+				continue
+			}
+			if sb.Len()+len(k)+2 > 850 {
+				return sb.String()
+			}
+			sb.WriteString(k)
+			sb.WriteString(". ")
+			break
+		}
+	}
+	return sb.String()
+}
+
 func makeOpenAIReq(in []byte) string {
 	url := "https://api.openai.com/v1/audio/transcriptions"
 
 	buf := new(bytes.Buffer)
 	w := multipart.NewWriter(buf)
 	w.WriteField("model", "whisper-1")
+	// Without an explicit language whisper-1 guesses per utterance and gets short
+	// commands wrong, sometimes returning English for German speech.
+	if lang := strings.Split(vars.APIConfig.STT.Language, "-")[0]; lang != "" {
+		w.WriteField("language", lang)
+	}
+	if vp := buildVocabPrompt(); vp != "" {
+		w.WriteField("prompt", vp)
+	}
 	sendFile, _ := w.CreateFormFile("file", "audio.mp3")
 	sendFile.Write(in)
 	w.Close()


### PR DESCRIPTION
I use STT_SERVICE=whisper (the OpenAI transcriptions API) with German. Two things
kept it from working properly. They are separate bugs but they show up as the same
symptom, so I put them in one PR.

## 1. The language gets reset to en-US on every start

In chipper/pkg/wirepod/preqs/server.go:

```go
if voiceProcessor != "vosk" && voiceProcessor != "whisper.cpp" {
    vars.APIConfig.STT.Language = "en-US"
}
```

The OpenAI processor is called "whisper", so it falls through and the language is
overwritten every single time the server starts. I could set de-DE in the web UI,
it was written to apiConfig.json, and it was gone again after the next restart.

That matters more than it looks, because the OpenAI TTS voice depends on it:

```go
// chipper/pkg/wirepod/ttr/kgsim_cmds.go:293
if (vars.APIConfig.STT.Language != "en-US" && vars.APIConfig.Knowledge.Provider == "openai") || ...
```

So with STT_SERVICE=whisper the non-English voice can never trigger. My robot kept
reading German text with the English on-board TTS, which is pretty much
unintelligible.

Fix is one condition:

```go
if voiceProcessor != "vosk" && voiceProcessor != "whisper.cpp" && voiceProcessor != "whisper" {
```

Log before:
```
Initiating whisper voice processor with language en-US
```
after:
```
Initiating whisper voice processor with language de-DE
```

## 2. The API call does not send `language` or `prompt`

makeOpenAIReq only sends the model and the audio file. whisper-1 then guesses the
language per utterance, and on short commands it guesses wrong. I had German
commands come back as English, for example my "Tschüss" was transcribed as
"see you, man."

I added two fields:

* `language`, taken from STT.Language ("de-DE" becomes "de")
* `prompt`, a vocabulary hint built from the loaded intents

The prompt is the part that made the real difference. whisper-1 accepts a prompt to
bias transcription towards expected wording, and since wire-pod already knows every
keyphrase it can match, it seemed wasteful not to pass them. buildVocabPrompt()
takes the first keyphrase of each intent and caps the whole string at 850
characters.

Before, "hol den Würfel":
```
Bot xxxx Transcribed text: eulenwürfel.
```
and on another try:
```
Bot xxxx Transcribed text: oh, den würfel.
```

After:
```
Bot xxxx Transcribed text: rolle den würfel.
Bot xxxx Partial match for intent intent_play_rollcube (rolle den würfel)
```
```
Bot xxxx Transcribed text: finde den würfel.
Bot xxxx Partial match for intent intent_imperative_findcube (finde den würfel)
```

This should help every non-English language, not just German. I am wondering if the
same prompt trick would be worth doing for whisper.cpp too, since that binding
supports an initial prompt as well, but I have not tried that.

One thing to flag: the prompt adds up to 850 characters to every transcription
request. That is a small amount of extra tokens per utterance, and I understand if
you would rather not have that on by default. I am happy to put it behind a config
option (something like a "send_vocab_prompt" flag next to the STT settings) or to
drop the prompt part and keep only the language field. Just say which you prefer
and I will push the change.