### PR TITLE
Knowledge graph model setting is ignored when the provider is OpenAI

### DIFF
--- a/chipper/pkg/wirepod/ttr/kgsim.go
+++ b/chipper/pkg/wirepod/ttr/kgsim.go
@@ -154,6 +154,9 @@ func CreateAIReq(transcribedText, esn string, gpt3tryagain, isKG bool) openai.Ch
 		model = openai.GPT3Dot5Turbo
 	} else if vars.APIConfig.Knowledge.Provider == "openai" {
 		model = openai.GPT4oMini
+		if m := strings.TrimSpace(vars.APIConfig.Knowledge.Model); m != "" {
+			model = m
+		}
 		logger.Println("Using " + model)
 	} else {
 		logger.Println("Using " + vars.APIConfig.Knowledge.Model)


### PR DESCRIPTION
I set gpt-4.1-mini as the model in the web UI, but the log kept saying it was using
gpt-4o-mini. The setting has no effect at all with the OpenAI provider.

In chipper/pkg/wirepod/ttr/kgsim.go, CreateAIReq:

```go
if gpt3tryagain {
    model = openai.GPT3Dot5Turbo
} else if vars.APIConfig.Knowledge.Provider == "openai" {
    model = openai.GPT4oMini
    logger.Println("Using " + model)
} else {
    logger.Println("Using " + vars.APIConfig.Knowledge.Model)
    model = vars.APIConfig.Knowledge.Model
}
```

The OpenAI branch never looks at Knowledge.Model. Only the "else" branch (Together,
custom endpoints) uses the configured value.

This PR makes the configured model win when it is set, and keeps GPT4oMini as the
fallback when the field is empty:

```go
} else if vars.APIConfig.Knowledge.Provider == "openai" {
    model = openai.GPT4oMini
    if m := strings.TrimSpace(vars.APIConfig.Knowledge.Model); m != "" {
        model = m
    }
    logger.Println("Using " + model)
}
```

That keeps the current behaviour for everyone who leaves the field empty, so it
should not change anything for existing setups.

I am not sure whether the hardcoding was on purpose, maybe to stop people from
picking a model that breaks the streaming or the command parsing. If that is the
reason, I would rather you close this and hide or disable the model field for the
OpenAI provider instead, because right now it looks like it works and silently does
nothing. Either way the current state is confusing.