### PR TITLE
Add local Vector names and eye-colored cards

### DIFF
--- a/chipper/pkg/servers/jdocs/botInfoStorer.go
+++ b/chipper/pkg/servers/jdocs/botInfoStorer.go
@@ -141,12 +141,9 @@ func StoreBotInfo(ctx context.Context, thing string) {
 	}
 	if appendNew {
 		logger.Println("Adding " + botEsn + " to bot info store")
-		vars.BotInfo.Robots = append(vars.BotInfo.Robots, struct {
-			Esn       string `json:"esn"`
-			IPAddress string `json:"ip_address"`
-			GUID      string `json:"guid"`
-			Activated bool   `json:"activated"`
-		}{Esn: botEsn, IPAddress: ipAddr, GUID: "", Activated: false})
+		vars.BotInfo.Robots = append(vars.BotInfo.Robots, vars.RobotInfo{
+			Esn: botEsn, IPAddress: ipAddr, GUID: "", Activated: false,
+		})
 	}
 	finalJsonBytes, _ := json.Marshal(vars.BotInfo)
 	os.WriteFile(vars.BotInfoPath, finalJsonBytes, 0644)

--- a/chipper/pkg/vars/vars.go
+++ b/chipper/pkg/vars/vars.go
@@ -87,14 +87,18 @@ type RememberedChat struct {
 var RememberedChats []RememberedChat
 
 type RobotInfoStore struct {
-	GlobalGUID string `json:"global_guid"`
-	Robots     []struct {
-		Esn       string `json:"esn"`
-		IPAddress string `json:"ip_address"`
-		// 192.168.1.150:443
-		GUID      string `json:"guid"`
-		Activated bool   `json:"activated"`
-	} `json:"robots"`
+	GlobalGUID string      `json:"global_guid"`
+	Robots     []RobotInfo `json:"robots"`
+}
+
+// RobotInfo is WirePod's local enrollment record. DisplayName is only a local
+// label; it never changes the robot serial number or cloud identity.
+type RobotInfo struct {
+	Esn         string `json:"esn"`
+	IPAddress   string `json:"ip_address"`
+	GUID        string `json:"guid"`
+	Activated   bool   `json:"activated"`
+	DisplayName string `json:"display_name,omitempty"`
 }
 
 type RecurringInfoStore struct {

--- a/chipper/pkg/wirepod/sdkapp/display_name.go
+++ b/chipper/pkg/wirepod/sdkapp/display_name.go
@@ -1,0 +1,62 @@
+package sdkapp
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"unicode"
+
+	"github.com/kercre123/wire-pod/chipper/pkg/vars"
+)
+
+const maxRobotDisplayNameRunes = 48
+
+var robotDisplayNameMu sync.Mutex
+
+func normalizedRobotDisplayName(name string) (string, error) {
+	name = strings.TrimSpace(name)
+	if len([]rune(name)) > maxRobotDisplayNameRunes {
+		return "", fmt.Errorf("display name must be %d characters or fewer", maxRobotDisplayNameRunes)
+	}
+	if strings.IndexFunc(name, unicode.IsControl) >= 0 {
+		return "", fmt.Errorf("display name cannot contain control characters")
+	}
+	return name, nil
+}
+
+func robotDisplayName(serial string) (string, bool) {
+	robotDisplayNameMu.Lock()
+	defer robotDisplayNameMu.Unlock()
+	for _, robot := range vars.BotInfo.Robots {
+		if strings.EqualFold(strings.TrimSpace(serial), robot.Esn) {
+			return robot.DisplayName, true
+		}
+	}
+	return "", false
+}
+
+func setRobotDisplayName(serial, name string) error {
+	name, err := normalizedRobotDisplayName(name)
+	if err != nil {
+		return err
+	}
+	robotDisplayNameMu.Lock()
+	defer robotDisplayNameMu.Unlock()
+	for i := range vars.BotInfo.Robots {
+		if !strings.EqualFold(strings.TrimSpace(serial), vars.BotInfo.Robots[i].Esn) {
+			continue
+		}
+		vars.BotInfo.Robots[i].DisplayName = name
+		contents, err := json.Marshal(vars.BotInfo)
+		if err != nil {
+			return fmt.Errorf("encode robot display name: %w", err)
+		}
+		if err := os.WriteFile(vars.BotInfoPath, contents, 0600); err != nil {
+			return fmt.Errorf("save robot display name: %w", err)
+		}
+		return nil
+	}
+	return fmt.Errorf("robot not found")
+}

--- a/chipper/pkg/wirepod/sdkapp/display_name_test.go
+++ b/chipper/pkg/wirepod/sdkapp/display_name_test.go
@@ -1,0 +1,53 @@
+package sdkapp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kercre123/wire-pod/chipper/pkg/vars"
+)
+
+func TestDisplayNameEndpointsPersistWithoutRobotConnection(t *testing.T) {
+	originalInfo, originalPath := vars.BotInfo, vars.BotInfoPath
+	vars.BotInfo = vars.RobotInfoStore{Robots: []vars.RobotInfo{{Esn: "robot"}}}
+	vars.BotInfoPath = filepath.Join(t.TempDir(), "botSdkInfo.json")
+	t.Cleanup(func() {
+		vars.BotInfo = originalInfo
+		vars.BotInfoPath = originalPath
+	})
+
+	save := httptest.NewRecorder()
+	SdkapiHandler(save, httptest.NewRequest(http.MethodPost, "/api-sdk/set_display_name?serial=robot&name=Sunbeam", nil))
+	if save.Code != http.StatusOK {
+		t.Fatalf("save status = %d, want %d: %s", save.Code, http.StatusOK, save.Body.String())
+	}
+
+	lookup := httptest.NewRecorder()
+	SdkapiHandler(lookup, httptest.NewRequest(http.MethodGet, "/api-sdk/get_display_name?serial=robot", nil))
+	if lookup.Code != http.StatusOK {
+		t.Fatalf("lookup status = %d, want %d: %s", lookup.Code, http.StatusOK, lookup.Body.String())
+	}
+	var payload map[string]string
+	if err := json.Unmarshal(lookup.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got := payload["display_name"]; got != "Sunbeam" {
+		t.Fatalf("display_name = %q, want Sunbeam", got)
+	}
+
+	contents, err := os.ReadFile(vars.BotInfoPath)
+	if err != nil {
+		t.Fatalf("read persisted robot metadata: %v", err)
+	}
+	var persisted vars.RobotInfoStore
+	if err := json.Unmarshal(contents, &persisted); err != nil {
+		t.Fatalf("decode persisted robot metadata: %v", err)
+	}
+	if got := persisted.Robots[0].DisplayName; got != "Sunbeam" {
+		t.Fatalf("persisted display name = %q, want Sunbeam", got)
+	}
+}

--- a/chipper/pkg/wirepod/sdkapp/server.go
+++ b/chipper/pkg/wirepod/sdkapp/server.go
@@ -28,7 +28,7 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 	robotObj, robotIndex, err := getRobot(r.FormValue("serial"))
 	robot := robotObj.Vector
 	ctx := robotObj.Ctx
-	if r.URL.Path != "/api-sdk/get_sdk_info" && r.URL.Path != "/api-sdk/debug" {
+	if r.URL.Path != "/api-sdk/get_sdk_info" && r.URL.Path != "/api-sdk/debug" && r.URL.Path != "/api-sdk/get_display_name" && r.URL.Path != "/api-sdk/set_display_name" {
 		if err != nil {
 			fmt.Fprint(w, "error: "+err.Error())
 			return
@@ -106,6 +106,23 @@ func SdkapiHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		fmt.Fprint(w, string(jsonBytes))
+		return
+	case r.URL.Path == "/api-sdk/get_display_name":
+		name, found := robotDisplayName(r.FormValue("serial"))
+		if !found {
+			http.Error(w, "robot not found", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"display_name": name})
+		return
+	case r.URL.Path == "/api-sdk/set_display_name":
+		if err := setRobotDisplayName(r.FormValue("serial"), r.FormValue("name")); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "saved"})
 		return
 	case r.URL.Path == "/api-sdk/get_sdk_settings":
 		i := 0

--- a/chipper/webroot/css/style.css
+++ b/chipper/webroot/css/style.css
@@ -413,9 +413,29 @@ input[type='radio']:disabled:after {
 .vectorFace {
   height: 60px;
   width: 60px;
+  position: relative;
+  isolation: isolate;
+  --vector-eye-tint: #35e0cf;
   background-position: center;
   background-size: contain;
   background-repeat: no-repeat;
+}
+
+/* Keep the original animated Vector artwork intact and tint only its eye field. */
+.vectorFace::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: var(--vector-eye-tint);
+  opacity: .76;
+  mix-blend-mode: color;
+  -webkit-mask-image:
+    radial-gradient(ellipse 17% 19% at 36% 50%, #000 67%, transparent 100%),
+    radial-gradient(ellipse 17% 19% at 65% 50%, #000 67%, transparent 100%);
+  mask-image:
+    radial-gradient(ellipse 17% 19% at 36% 50%, #000 67%, transparent 100%),
+    radial-gradient(ellipse 17% 19% at 65% 50%, #000 67%, transparent 100%);
 }
 
 .batteryLevel {

--- a/chipper/webroot/css/style.css
+++ b/chipper/webroot/css/style.css
@@ -430,12 +430,9 @@ input[type='radio']:disabled:after {
   background: var(--vector-eye-tint);
   opacity: .76;
   mix-blend-mode: color;
-  -webkit-mask-image:
-    radial-gradient(ellipse 17% 19% at 36% 50%, #000 67%, transparent 100%),
-    radial-gradient(ellipse 17% 19% at 65% 50%, #000 67%, transparent 100%);
-  mask-image:
-    radial-gradient(ellipse 17% 19% at 36% 50%, #000 67%, transparent 100%),
-    radial-gradient(ellipse 17% 19% at 65% 50%, #000 67%, transparent 100%);
+  /* One shared, rounded eye canvas. Individual circular masks clipped moving
+     expressions at their edges, especially on the red eye animation. */
+  clip-path: inset(29% 17% 29% 17% round 30%);
 }
 
 .batteryLevel {

--- a/chipper/webroot/js/battery.js
+++ b/chipper/webroot/js/battery.js
@@ -15,6 +15,54 @@ const hnyGifs = [
 
 const hnyGif = hnyGifs[Math.floor(Math.random() * hnyGifs.length)];
 
+const vectorEyeTints = [
+  "#35e0cf", "#ff9a3d", "#ffd84d", "#b7f34d",
+  "#4db8ff", "#b68cff", "#6eea8f"
+];
+
+function applyVectorEyeTint(vectorFace, settings) {
+  if (!vectorFace || !settings) return;
+  const custom = settings.custom_eye_color;
+  if (custom && custom.enabled && Number.isFinite(Number(custom.hue))) {
+    const hue = ((Number(custom.hue) % 1) + 1) % 1 * 360;
+    const saturation = Math.max(0, Math.min(100, Number(custom.saturation) * 100 || 0));
+    vectorFace.style.setProperty("--vector-eye-tint", `hsl(${hue} ${saturation}% 58%)`);
+    return;
+  }
+  const preset = Number(settings.eye_color);
+  if (Number.isInteger(preset) && vectorEyeTints[preset]) {
+    vectorFace.style.setProperty("--vector-eye-tint", vectorEyeTints[preset]);
+  }
+}
+
+async function loadVectorEyeTint(vectorFace, serial) {
+  try {
+    const response = await fetch("/api-sdk/get_sdk_settings?serial=" + encodeURIComponent(serial), {
+      method: "POST", cache: "no-store"
+    });
+    if (response.ok) applyVectorEyeTint(vectorFace, await response.json());
+  } catch {
+    // A reconnecting Vector can still render a useful battery card.
+  }
+}
+
+function setRobotCardDetails(tooltip, serial, displayName, lines) {
+  tooltip.replaceChildren();
+  const name = document.createElement("b");
+  name.textContent = displayName || serial;
+  tooltip.appendChild(name);
+  if (displayName) {
+    tooltip.appendChild(document.createElement("br"));
+    const serialLine = document.createElement("span");
+    serialLine.textContent = serial;
+    tooltip.appendChild(serialLine);
+  }
+  for (const line of lines) {
+    tooltip.appendChild(document.createElement("br"));
+    tooltip.appendChild(document.createTextNode(line));
+  }
+}
+
 function getBatteryPercentage(voltage) {
   let percentage;
   const maxVoltage = 4.1; // Maximum voltage for the battery
@@ -43,7 +91,7 @@ function getBatteryPercentage(voltage) {
 }
 
 
-async function updateBatteryInfo(serial, i) {
+async function updateBatteryInfo(serial, i, displayName = "") {
   var batteryContainer = document.getElementsByClassName("batteryContainer")[i];
   if (!batteryContainer) {
     return;
@@ -72,10 +120,10 @@ async function updateBatteryInfo(serial, i) {
     }
     batteryLevel.className = "batteryLevel batteryUnknown";
     vectorFace.style.backgroundImage = "url(/assets/wififace.gif)";
-    tooltip.innerHTML = `<b>${serial}</b><br/>??%<br/> (Unable to connect)`;
+    setRobotCardDetails(tooltip, serial, displayName, ["??%", "(Unable to connect)"]);
     setTimeout(async () => {
       // Re-render the battery information
-      updateBatteryInfo(serial, i);
+      updateBatteryInfo(serial, i, displayName);
     }, 6000);
     return;
   }
@@ -106,7 +154,7 @@ async function updateBatteryInfo(serial, i) {
   batteryLevel.style.width = batteryPercentage + "%";
 
   // Clear tooltip, and replace serial number and the latest voltage
-  tooltip.innerHTML = `<b>${serial}</b><br/>~${batteryPercentage}%<br/> (${batteryStatus["battery_volts"].toFixed(2)}V)`;
+  setRobotCardDetails(tooltip, serial, displayName, [`~${batteryPercentage}%`, `(${batteryStatus["battery_volts"].toFixed(2)}V)`]);
 
   // Update the charging status
   if (batteryStatus["is_on_charger_platform"]) {
@@ -155,11 +203,11 @@ async function updateBatteryInfo(serial, i) {
 
   setTimeout(async () => {
     // Re-render the battery information
-    updateBatteryInfo(serial, i);
+    updateBatteryInfo(serial, i, displayName);
   }, 3000);
 }
 
-async function renderBatteryInfo(serial, i = 0) {
+async function renderBatteryInfo(serial, i = 0, displayName = "") {
   // For each robot, we'll create a new div to hold the battery information with a class of "batteryContainer"
   var batteryContainer = document.createElement("div");
   batteryContainer.className = "batteryContainer";
@@ -172,7 +220,7 @@ async function renderBatteryInfo(serial, i = 0) {
 
   var tooltip = document.createElement("span");
   tooltip.className = "tooltip";
-  tooltip.innerHTML = `<b>${serial}</b>`;
+  setRobotCardDetails(tooltip, serial, displayName, []);
   batteryContainer.appendChild(tooltip);
 
   // Create a new div to hold the battery status with a class of "batteryOutline", this will be the outline of the battery status
@@ -184,6 +232,7 @@ async function renderBatteryInfo(serial, i = 0) {
   vectorFace.className = "vectorFace";
   vectorFace.style.backgroundImage = "url(/assets/webface.gif)"; // default loading face
   batteryContainer.appendChild(vectorFace);
+  loadVectorEyeTint(vectorFace, serial);
 
   // Create the colored div that will represent the battery level, with a class of "batteryLevel"
   var batteryLevel = document.createElement("div");
@@ -208,10 +257,10 @@ async function renderBatteryInfo(serial, i = 0) {
   if (!batteryStatus) {
     batteryLevel.className = "batteryLevel batteryUnknown";
     vectorFace.style.backgroundImage = "url(/assets/wififace.gif)";
-    tooltip.innerHTML = `<b>${serial}</b><br/>??<br/> (Unable to connect)`;
+    setRobotCardDetails(tooltip, serial, displayName, ["??", "(Unable to connect)"]);
     setTimeout(async () => {
       // Re-render the battery information
-      updateBatteryInfo(serial, i);
+      updateBatteryInfo(serial, i, displayName);
     }, 6000);
     return;
   }
@@ -238,7 +287,7 @@ async function renderBatteryInfo(serial, i = 0) {
 
   setTimeout(async () => {
     // Re-render the battery information
-    updateBatteryInfo(serial, i);
+    updateBatteryInfo(serial, i, displayName);
   }, 3000);
 }
 
@@ -258,9 +307,8 @@ async function processBotStats() {
     }
 
     for (var i = 0; i < sdkInfo["robots"].length; i++) {
-      const serial = sdkInfo["robots"][i]["esn"];
-
-      renderBatteryInfo(serial, i);
+      const robot = sdkInfo["robots"][i];
+      renderBatteryInfo(robot["esn"], i, robot["display_name"] || "");
     }
   } catch {
     // Do nothing

--- a/chipper/webroot/sdkapp/js/main.js
+++ b/chipper/webroot/sdkapp/js/main.js
@@ -14,6 +14,35 @@ esn = urlParams.get("serial");
 
 var client = new HttpClient();
 getCurrentSettings();
+loadRobotDisplayName();
+
+async function loadRobotDisplayName() {
+  const field = document.getElementById("robotDisplayName");
+  if (!field || !esn) return;
+  try {
+    const response = await fetch("/api-sdk/get_display_name?serial=" + encodeURIComponent(esn), {cache: "no-store"});
+    if (response.ok) field.value = (await response.json()).display_name || "";
+  } catch {
+    // Naming is optional local metadata.
+  }
+}
+
+async function saveRobotDisplayName() {
+  const field = document.getElementById("robotDisplayName");
+  const status = document.getElementById("robotDisplayNameStatus");
+  if (!field || !status || !esn) return;
+  status.textContent = "Saving…";
+  try {
+    const response = await fetch(
+      "/api-sdk/set_display_name?serial=" + encodeURIComponent(esn) + "&name=" + encodeURIComponent(field.value.trim()),
+      {method: "POST", cache: "no-store"}
+    );
+    if (!response.ok) throw new Error("save failed");
+    status.textContent = field.value.trim() ? "Name saved." : "Name cleared; the serial number will be shown.";
+  } catch {
+    status.textContent = "Unable to save the name. Please try again.";
+  }
+}
 
 function revealSdkActions() {
   var x = document.getElementById("sdkActions");
@@ -283,6 +312,9 @@ function getCurrentSettings() {
   xhr.onload = function () {
     var jdocSdkSettingsResponse1 = JSON.stringify(xhr.response);
     jdocSdk = JSON.parse(jdocSdkSettingsResponse1);
+    if (typeof applyVectorEyeTint === "function") {
+      applyVectorEyeTint(document.querySelector("#botStats .vectorFace"), jdocSdk);
+    }
     let xhr2 = new XMLHttpRequest();
     if (jdocSdk["custom_eye_color"]) {
       var customECE = jdocSdk["custom_eye_color"]["enabled"];

--- a/chipper/webroot/sdkapp/settings.html
+++ b/chipper/webroot/sdkapp/settings.html
@@ -23,9 +23,11 @@
       <div id="botStats"></div>
       <hr>
       <div class="main-nav-parent">
-        <div class="main-nav-child"><a href="/sdkapp"><i class="fa-solid fa-reply"></i><br />Back</a></div>
+        <div class="main-nav-child"><a href="/"><i class="fa-solid fa-reply"></i><br />Home</a></div>
         <div class="main-nav-child"><a href="#" onclick="goToControlPage()"><i
               class="fa-solid fa-gamepad"></i><br />Control<br /></a></div>
+        <div class="main-nav-child"><a href="#" onclick="showSection('section-name'); return false;"><i
+              class="fa-solid fa-tag"></i><br />Name</a></div>
         <div class="main-nav-child"><a href="#" onclick="showSection('section-volume'); return false;"><i
               class="fa-solid fa-volume-high" id="icon-volume" name="icon"></i><br />Volume</a></div>
         <div class="main-nav-child"><a href="#" onclick="showSection('section-eyes'); return false;"><i
@@ -56,6 +58,19 @@
               class="fa-solid fa-hourglass" id="icon-timezone" name="icon"></i><br />Time Zone</a></div>
       </div>
       <hr>
+
+      <div id="section-name" class="toggleable-section" style="display:none;">
+        <h2 class="center">Wire-Pod Name</h2>
+        <hr class="small-hr">
+        <p class="center">A local label for this Vector. It does not change the robot's serial number or cloud identity.</p>
+        <div class="center">
+          <label for="robotDisplayName">Name</label><br>
+          <input class="tinput" id="robotDisplayName" type="text" maxlength="48" autocomplete="off" placeholder="Give this Vector a name">
+        </div>
+        <div class="center"><button onclick="saveRobotDisplayName()">Save name</button></div>
+        <p class="center" id="robotDisplayNameStatus" aria-live="polite"></p>
+        <hr>
+      </div>
 
       <div id="section-volume" class="toggleable-section" style="display:none;">
         <h2 class="center">Volume</h2>


### PR DESCRIPTION
## Summary
- add a persistent, WirePod-local display name for each enrolled Vector
- show names on battery cards while retaining the serial number
- tint only the animated eye field to match the configured preset or custom eye color
- add a Name panel in Vector settings and make its navigation return Home

The display name is local metadata only; it does not change Vector firmware, serials, or cloud identity.

<img width="940" height="442" alt="Screenshot 2026-09-12 at 1 47 12 AM" src="https://github.com/user-attachments/assets/db36aee7-c190-40e1-aa2a-48a4f6941281" />

<img width="919" height="450" alt="Screenshot 2026-09-12 at 1 54 46 AM" src="https://github.com/user-attachments/assets/f4f938c4-33b4-4e07-ad39-47edc2edf2da" />


## Validation
- `go test -race -count=1 -tags nolibopusfile ./pkg/wirepod/sdkapp ./pkg/servers/jdocs ./pkg/vars`
- `node --check chipper/webroot/js/battery.js`
- `node --check chipper/webroot/sdkapp/js/main.js`